### PR TITLE
chore: add astro sync to dev/build and a preview script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
 	"type": "module",
 	"version": "0.0.2",
 	"scripts": {
-		"dev": "astro dev",
-		"build": "astro build",
+		"dev": "astro sync && astro dev",
+		"build": "astro sync && astro build",
+		"preview": "astro preview",
 		"check": "astro check",
 		"lint": "biome check",
 		"format": "biome check --write",


### PR DESCRIPTION
## Summary
- Prepend `astro sync` to the `dev` and `build` scripts so generated types (content collections, env, etc.) are always up to date before running.
- Add a `preview` script (`astro preview`) for previewing production builds locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)