### PR TITLE
fix: remove console.info and only widen footer on note posts

### DIFF
--- a/src/components/shared/footer.astro
+++ b/src/components/shared/footer.astro
@@ -72,11 +72,9 @@ const items = [
 <script is:inline>
   document.addEventListener("DOMContentLoaded", () => {
     const footer = document.querySelector("[data-footer=true]");
-    console.info(footer);
     if (footer) {
-      const isPostPage = window.location.pathname.includes("/notes/");
+      const isPostPage = /\/notes\/[^/]+/.test(window.location.pathname);
       if (isPostPage) {
-        console.info(isPostPage);
         footer.classList.add("max-w-5xl");
       }
     }


### PR DESCRIPTION
## Summary
- Remove the `console.info` debug logging from the footer width script
- Only widen the footer to `max-w-5xl` on actual note posts (`/notes/<slug>`), not the plain `/notes/` listing page

## Why
The script widened the footer for any path containing `/notes/`, which also matched the plain `/notes/` index page. That page uses the narrower `max-w-3xl` content width, so its footer ended up wider than its content. The new check `/\/notes\/[^/]+/` matches only post pages (including `/id/notes/<slug>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)