### PR TITLE
Make archive photos crawlable + optimized, and rebuild the lightbox on Motion + Base UI

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -55,6 +55,9 @@ export default defineConfig({
 			changefreq: "daily",
 			lastmod: new Date(),
 			i18n: { defaultLocale: "en", locales: { en: "en", id: "id" } },
+			// The image sitemap is emitted by its own endpoint and advertised in
+			// robots.txt; keep it out of the page sitemap.
+			filter: (page) => !page.endsWith("/sitemap-images.xml"),
 		}),
 	],
 

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
 		"sharp": "^0.35.2",
 		"tailwind-merge": "^3.6.0",
 		"tailwindcss": "^4.3.1",
-		"ts-pattern": "^5.9.0",
-		"vaul": "^1.1.2"
+		"ts-pattern": "^5.9.0"
 	},
 	"devDependencies": {
 		"@astrojs/ts-plugin": "^1.10.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,9 +104,6 @@ importers:
       ts-pattern:
         specifier: ^5.9.0
         version: 5.9.0
-      vaul:
-        specifier: ^1.1.2
-        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@astrojs/ts-plugin':
         specifier: ^1.10.9
@@ -1473,177 +1470,6 @@ packages:
   '@preact/signals-core@1.14.3':
     resolution: {integrity: sha512-m0K3vnbSLC5rHs2ZVfeAMvBtT1zIyq4mxx5OlNncSgMj5Iz6W5Rn3kPrDxAC+iIKmiVe0lSl6U37t5ZkEWoVAw==}
 
-  '@radix-ui/primitive@1.1.4':
-    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
-
-  '@radix-ui/react-compose-refs@1.1.3':
-    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-context@1.1.4':
-    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-dialog@1.1.17':
-    resolution: {integrity: sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-dismissable-layer@1.1.13':
-    resolution: {integrity: sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-focus-guards@1.1.4':
-    resolution: {integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-focus-scope@1.1.10':
-    resolution: {integrity: sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-id@1.1.2':
-    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-portal@1.1.12':
-    resolution: {integrity: sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-presence@1.1.6':
-    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-primitive@2.1.6':
-    resolution: {integrity: sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-slot@1.3.0':
-    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-callback-ref@1.1.2':
-    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-controllable-state@1.2.3':
-    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-effect-event@0.0.3':
-    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-escape-keydown@1.1.2':
-    resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-layout-effect@1.1.2':
-    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@rolldown/binding-android-arm64@1.1.3':
     resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2093,10 +1919,6 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  aria-hidden@1.2.6:
-    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
-    engines: {node: '>=10'}
-
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -2532,9 +2354,6 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  detect-node-es@1.1.0:
-    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
-
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
@@ -2884,10 +2703,6 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
-
-  get-nonce@1.0.1:
-    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
-    engines: {node: '>=6'}
 
   get-own-enumerable-keys@1.0.0:
     resolution: {integrity: sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==}
@@ -3966,36 +3781,6 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-remove-scroll-bar@2.3.8:
-    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  react-remove-scroll@2.7.2:
-    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  react-style-singleton@2.2.3:
-    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
@@ -4593,26 +4378,6 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
-  use-callback-ref@1.3.3:
-    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  use-sidecar@1.1.3:
-    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -4628,12 +4393,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  vaul@1.1.2:
-    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
-    peerDependencies:
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -6277,148 +6036,6 @@ snapshots:
 
   '@preact/signals-core@1.14.3': {}
 
-  '@radix-ui/primitive@1.1.4': {}
-
-  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-context@1.1.4(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-dialog@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      aria-hidden: 1.2.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-dismissable-layer@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-focus-scope@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-id@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-portal@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-primitive@2.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-slot@1.3.0(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
   '@rolldown/binding-android-arm64@1.1.3':
     optional: true
 
@@ -6815,10 +6432,6 @@ snapshots:
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
-
-  aria-hidden@1.2.6:
-    dependencies:
-      tslib: 2.8.1
 
   aria-query@5.3.2: {}
 
@@ -7313,8 +6926,6 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  detect-node-es@1.1.0: {}
-
   devalue@5.8.1: {}
 
   devlop@1.1.0:
@@ -7725,8 +7336,6 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.4
       math-intrinsics: 1.1.0
-
-  get-nonce@1.0.1: {}
 
   get-own-enumerable-keys@1.0.0: {}
 
@@ -9063,33 +8672,6 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  react-remove-scroll@2.7.2(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.17)(react@19.2.7)
-      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
-      tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.17)(react@19.2.7)
-      use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      get-nonce: 1.0.1
-      react: 19.2.7
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.17
-
   react@19.2.7: {}
 
   readable-stream@3.6.2:
@@ -9840,21 +9422,6 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  use-sidecar@1.1.3(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      detect-node-es: 1.1.0
-      react: 19.2.7
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.17
-
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -9864,15 +9431,6 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
-
-  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@radix-ui/react-dialog': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
 
   vfile-location@5.0.3:
     dependencies:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,3 +3,4 @@ Allow: /
 
 Sitemap: https://rimzzlabs.com/sitemap-index.xml
 Sitemap: https://rimzzlabs.com/sitemap-0.xml
+Sitemap: https://rimzzlabs.com/sitemap-images.xml

--- a/src/components/home/archive.astro
+++ b/src/components/home/archive.astro
@@ -2,6 +2,7 @@
 import type { Lang } from "@/i18n/config";
 import { getDictionary } from "@/i18n/dictionary";
 import Section from "../shared/section.astro";
+import { getOptimizedImagesByYear } from "./archive/archive-optimized";
 import { ArchiveTimeline } from "./archive/archive-timeline";
 
 interface Props {
@@ -10,6 +11,7 @@ interface Props {
 
 const { lang } = Astro.props;
 const t = getDictionary(lang).archive;
+const images = await getOptimizedImagesByYear();
 ---
 
 <Section class="py-10">
@@ -20,5 +22,5 @@ const t = getDictionary(lang).archive;
     {t.intro}
   </p>
 
-  <ArchiveTimeline client:idle lang={lang} />
+  <ArchiveTimeline client:idle lang={lang} images={images} />
 </Section>

--- a/src/components/home/archive/archive-carousel-popup.tsx
+++ b/src/components/home/archive/archive-carousel-popup.tsx
@@ -29,18 +29,19 @@ const description = "Swipe or use the arrow buttons to browse the photos.";
  * screens. Controlled by the tapped photo index (`null` = closed).
  */
 export function ArchiveCarouselPopup({
+	open,
 	photos,
 	label,
 	index,
 	onClose,
 }: {
+	open: boolean;
 	photos: Array<Photo>;
 	label: string;
-	index: number | null;
+	index?: number;
 	onClose: () => void;
 }) {
 	const isMobile = useIsMobile();
-	const open = index !== null;
 
 	function onOpenChange(next: boolean) {
 		if (!next) onClose();
@@ -58,7 +59,7 @@ export function ArchiveCarouselPopup({
 						</DrawerClose>
 					</DrawerHeader>
 					<div className="px-12 py-6">
-						<ArchiveCarousel key={index ?? "closed"} photos={photos} startIndex={index ?? 0} />
+						<ArchiveCarousel key={index ?? "closed"} photos={photos} startIndex={index} />
 					</div>
 				</DrawerContent>
 			</Drawer>
@@ -76,7 +77,7 @@ export function ArchiveCarouselPopup({
 					</AlertDialogCancel>
 				</AlertDialogHeader>
 				<div className="px-12 py-6">
-					<ArchiveCarousel key={index ?? "closed"} photos={photos} startIndex={index ?? 0} />
+					<ArchiveCarousel key={index ?? "closed"} photos={photos} startIndex={index} />
 				</div>
 			</AlertDialogContent>
 		</AlertDialog>

--- a/src/components/home/archive/archive-carousel.tsx
+++ b/src/components/home/archive/archive-carousel.tsx
@@ -14,7 +14,7 @@ export function ArchiveCarousel({
 	startIndex,
 }: {
 	photos: Array<Photo>;
-	startIndex: number;
+	startIndex?: number;
 }) {
 	const motionEnabled = useMotionEnabled();
 
@@ -25,11 +25,15 @@ export function ArchiveCarousel({
 		>
 			<CarouselContent>
 				{photos.map((photo) => (
-					<CarouselItem key={photo.image.src} className="flex items-center justify-center">
+					<CarouselItem key={photo.src} className="flex items-center justify-center">
 						<figure className="w-full">
 							<img
-								src={photo.image.src}
+								src={photo.src}
+								srcSet={photo.srcSet}
+								sizes="364px"
 								alt={photo.alt}
+								width={photo.width}
+								height={photo.height}
 								className="max-h-[70vh] w-auto rounded-lg object-contain md:max-h-[60vh]"
 							/>
 							<figcaption className="pt-2 text-sm text-muted-foreground">{photo.alt}</figcaption>

--- a/src/components/home/archive/archive-images.ts
+++ b/src/components/home/archive/archive-images.ts
@@ -1,0 +1,47 @@
+import type { ImageMetadata } from "astro";
+import classroom from "@/assets/classroom.webp";
+import coinfest0 from "@/assets/coinfest-0.webp";
+import coinfest1 from "@/assets/coinfest-1.webp";
+import coinfest2 from "@/assets/coinfest-2.webp";
+import festPass from "@/assets/fest-pass.webp";
+import finalAssignment0 from "@/assets/final-assignment-0.webp";
+import graduation0 from "@/assets/graduation-0.webp";
+import laptop from "@/assets/laptop.webp";
+import pc0 from "@/assets/pc-0.webp";
+import pc1 from "@/assets/pc-1.webp";
+import pc2 from "@/assets/pc-2.webp";
+import pcLabs from "@/assets/pc-labs.webp";
+import rebuild0 from "@/assets/rebuild-0.webp";
+import rebuild1 from "@/assets/rebuild-1.webp";
+import rebuild2 from "@/assets/rebuild-2.webp";
+import rebuild3 from "@/assets/rebuild-3.webp";
+import selfie from "@/assets/selfie.webp";
+import wfc0 from "@/assets/wfc-0.webp";
+import wfc1 from "@/assets/wfc-1.webp";
+
+/**
+ * A build-time optimized archive photo: a resized fallback `src`, a responsive
+ * `srcSet`, and the intrinsic dimensions for aspect-ratio reservation. Produced by
+ * `getOptimizedImagesByYear` (server-only) and threaded into the island as props,
+ * since `getImage` can't run inside a React island.
+ */
+export type OptimizedImage = {
+	src: string;
+	srcSet: string;
+	width: number;
+	height: number;
+};
+
+// Images are structural and keyed by year in display order; their localized alt
+// text (and the title + descriptions) come from the dictionary. Shared by the
+// archive timeline island and the image sitemap endpoint (`sitemap-images.xml`).
+export const imagesByYear: Record<number, Array<ImageMetadata>> = {
+	2026: [],
+	2025: [],
+	2024: [festPass, coinfest1, coinfest0, coinfest2, finalAssignment0, graduation0],
+	2023: [rebuild1, rebuild0, rebuild3, rebuild2],
+	2022: [wfc0, wfc1],
+	2021: [selfie, laptop],
+	2020: [pc0, pc1, pc2],
+	2019: [classroom, pcLabs],
+};

--- a/src/components/home/archive/archive-optimized.ts
+++ b/src/components/home/archive/archive-optimized.ts
@@ -1,0 +1,36 @@
+import { getImage } from "astro:assets";
+import type { ImageMetadata } from "astro";
+import { imagesByYear, type OptimizedImage } from "./archive-images";
+
+// Both display contexts are small — grid tiles render at ~180px and the carousel
+// caps at 364px — so we cap the base render at 800px (enough for a 2x carousel)
+// and hand the browser a 200/400/800 srcset. `getImage` is server-only and can't
+// run inside the React island, so we optimize here at build time and pass plain,
+// serializable image data down as props (and reuse it for the image sitemap).
+const PHOTO_MAX_WIDTH = 800;
+const PHOTO_WIDTHS = [200, 400, 800];
+
+async function optimize(image: ImageMetadata): Promise<OptimizedImage> {
+	const result = await getImage({
+		src: image,
+		width: Math.min(PHOTO_MAX_WIDTH, image.width),
+		widths: PHOTO_WIDTHS,
+		format: "webp",
+	});
+	return {
+		src: result.src,
+		srcSet: result.srcSet.attribute,
+		width: result.attributes.width,
+		height: result.attributes.height,
+	};
+}
+
+export async function getOptimizedImagesByYear(): Promise<Record<number, Array<OptimizedImage>>> {
+	const entries = await Promise.all(
+		Object.entries(imagesByYear).map(async ([year, images]) => {
+			const optimized = await Promise.all(images.map(optimize));
+			return [Number(year), optimized] as const;
+		}),
+	);
+	return Object.fromEntries(entries);
+}

--- a/src/components/home/archive/archive-photos.tsx
+++ b/src/components/home/archive/archive-photos.tsx
@@ -1,9 +1,13 @@
-import type { ImageMetadata } from "astro";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { ArchiveCarouselPopup } from "./archive-carousel-popup";
+import type { OptimizedImage } from "./archive-images";
 
-export type Photo = { image: ImageMetadata; alt: string };
+export type Photo = OptimizedImage & { alt: string };
+
+// Grid tiles render at ~1/4 of the content column on desktop, roughly full-width
+// (2-up) on mobile; the wide first tile spans both columns.
+const GRID_SIZES = "(min-width: 1024px) 200px, 45vw";
 
 /**
  * Bento grid of a timeline's photos: uniform cropped tiles, with the first tile
@@ -11,7 +15,8 @@ export type Photo = { image: ImageMetadata; alt: string };
  * (shared `layoutId`) into the carousel popup on that photo.
  */
 export function ArchivePhotos({ photos, label }: { photos: Array<Photo>; label: string }) {
-	const [index, setIndex] = useState<number | null>(null);
+	const [index, setIndex] = useState<number>(0);
+	const [open, setOpen] = useState(false);
 
 	const wideFirst = photos.length % 2 === 1;
 
@@ -20,9 +25,12 @@ export function ArchivePhotos({ photos, label }: { photos: Array<Photo>; label: 
 			<div className="grid grid-cols-2 gap-2">
 				{photos.map((photo, i) => (
 					<button
-						key={photo.image.src}
+						key={photo.src}
 						type="button"
-						onClick={() => setIndex(i)}
+						onClick={() => {
+							setIndex(i);
+							setOpen(true);
+						}}
 						aria-label={`Open photo: ${photo.alt}`}
 						className={cn(
 							"group relative overflow-hidden rounded-lg border bg-muted outline-none focus-visible:ring-2 focus-visible:ring-ring",
@@ -30,8 +38,12 @@ export function ArchivePhotos({ photos, label }: { photos: Array<Photo>; label: 
 						)}
 					>
 						<img
-							src={photo.image.src}
+							src={photo.src}
+							srcSet={photo.srcSet}
+							sizes={GRID_SIZES}
 							alt={photo.alt}
+							width={photo.width}
+							height={photo.height}
 							loading="lazy"
 							decoding="async"
 							className="size-full object-cover transition-transform duration-300 motion-safe:group-hover:scale-105"
@@ -41,10 +53,13 @@ export function ArchivePhotos({ photos, label }: { photos: Array<Photo>; label: 
 			</div>
 
 			<ArchiveCarouselPopup
+				open={open}
 				photos={photos}
 				label={label}
 				index={index}
-				onClose={() => setIndex(null)}
+				onClose={() => {
+					setOpen(false);
+				}}
 			/>
 		</>
 	);

--- a/src/components/home/archive/archive-timeline-item.tsx
+++ b/src/components/home/archive/archive-timeline-item.tsx
@@ -29,12 +29,10 @@ export function ArchiveTimelineItem(props: ArchiveTimelineItemProps) {
 				<ContentTitle year={props.year} title={props.title} />
 				{props.photos.length > 0 ? (
 					<div className="flex flex-col gap-4 lg:grid lg:grid-cols-2 lg:items-start">
-						<div className="order-2 lg:order-1">
+						<div>
 							<ArchiveDescriptions items={props.descriptions} />
 						</div>
-						<div className="order-1 lg:order-2">
-							<ArchivePhotos photos={props.photos} label={`${props.year}, ${props.title}`} />
-						</div>
+						<ArchivePhotos photos={props.photos} label={`${props.year}, ${props.title}`} />
 					</div>
 				) : (
 					<ArchiveDescriptions items={props.descriptions} />

--- a/src/components/home/archive/archive-timeline.tsx
+++ b/src/components/home/archive/archive-timeline.tsx
@@ -1,42 +1,16 @@
-import type { ImageMetadata } from "astro";
-import classroom from "@/assets/classroom.webp";
-import coinfest0 from "@/assets/coinfest-0.webp";
-import coinfest1 from "@/assets/coinfest-1.webp";
-import coinfest2 from "@/assets/coinfest-2.webp";
-import festPass from "@/assets/fest-pass.webp";
-import finalAssignment0 from "@/assets/final-assignment-0.webp";
-import graduation0 from "@/assets/graduation-0.webp";
-import laptop from "@/assets/laptop.webp";
-import pc0 from "@/assets/pc-0.webp";
-import pc1 from "@/assets/pc-1.webp";
-import pc2 from "@/assets/pc-2.webp";
-import pcLabs from "@/assets/pc-labs.webp";
-import rebuild0 from "@/assets/rebuild-0.webp";
-import rebuild1 from "@/assets/rebuild-1.webp";
-import rebuild2 from "@/assets/rebuild-2.webp";
-import rebuild3 from "@/assets/rebuild-3.webp";
-import selfie from "@/assets/selfie.webp";
-import wfc0 from "@/assets/wfc-0.webp";
-import wfc1 from "@/assets/wfc-1.webp";
 import type { Lang } from "@/i18n/config";
 import { getDictionary } from "@/i18n/dictionary";
 import { Accordion } from "../../ui/accordion";
+import type { OptimizedImage } from "./archive-images";
 import { ArchiveTimelineItem } from "./archive-timeline-item";
 
-// Images are structural and stay here, keyed by year and in display order; their
-// localized alt text (and the title + descriptions) come from the dictionary.
-const imagesByYear: Record<number, Array<ImageMetadata>> = {
-	2026: [],
-	2025: [],
-	2024: [festPass, coinfest1, coinfest0, coinfest2, finalAssignment0, graduation0],
-	2023: [rebuild1, rebuild0, rebuild3, rebuild2],
-	2022: [wfc0, wfc1],
-	2021: [selfie, laptop],
-	2020: [pc0, pc1, pc2],
-	2019: [classroom, pcLabs],
-};
-
-export function ArchiveTimeline({ lang }: { lang: Lang }) {
+export function ArchiveTimeline({
+	lang,
+	images,
+}: {
+	lang: Lang;
+	images: Record<number, Array<OptimizedImage>>;
+}) {
 	const timeline = getDictionary(lang).archive.timeline;
 	const years = Object.keys(timeline)
 		.map(Number)
@@ -49,8 +23,8 @@ export function ArchiveTimeline({ lang }: { lang: Lang }) {
 		>
 			{years.map((year) => {
 				const entry = timeline[String(year) as keyof typeof timeline];
-				const photos = (imagesByYear[year] ?? []).map((image, i) => ({
-					image,
+				const photos = (images[year] ?? []).map((image, i) => ({
+					...image,
 					alt: entry.photoAlts[i] ?? "",
 				}));
 				return (

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,7 +1,7 @@
 import { Accordion as AccordionPrimitive } from "@base-ui/react/accordion";
 import { ChevronDownIcon } from "lucide-react";
 import { type HTMLMotionProps, motion } from "motion/react";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext } from "react";
 import { useMotionEnabled } from "@/hooks/use-motion";
 import { INSTANT, SPRING } from "@/lib/motion";
 import { cn } from "@/lib/utils";
@@ -114,11 +114,13 @@ interface AccordionContentPanelProps {
  * Renders the base-ui panel as a `motion.div` that animates its height. The inner
  * content's own entrance (fades, slides, stagger) is left to the consumer.
  *
- * base-ui drives unmount/`hidden` off CSS animation-end events, which never fire
- * for a JS animation — so we use `keepMounted`, strip its `hidden` attribute, and
- * re-apply `hidden` ourselves only after the collapse finishes (deferred hidden).
- * This keeps collapsed content out of the a11y tree and tab order without cutting
- * the animation short.
+ * base-ui drives unmount/`hidden` (display:none) off CSS animation-end events,
+ * which never fire for a JS animation — and a display:none panel drops its content
+ * from the rendered DOM that image crawlers read (the archive photos live in here).
+ * So we `keepMounted`, strip base-ui's `hidden`, and collapse purely by animating
+ * height to 0. When closed the panel is marked `inert`, which keeps its content out
+ * of the a11y tree and tab order (as `hidden` did) while leaving the markup
+ * rendered and crawlable.
  */
 function AccordionContentPanel({
 	panelProps,
@@ -128,22 +130,14 @@ function AccordionContentPanel({
 	children,
 }: AccordionContentPanelProps) {
 	const { hidden: _baseHidden, style, ...rest } = panelProps;
-	const [collapsed, setCollapsed] = useState(!open);
-
-	useEffect(() => {
-		if (open) setCollapsed(false);
-	}, [open]);
 
 	return (
 		<motion.div
 			{...(rest as HTMLMotionProps<"div">)}
-			hidden={collapsed || undefined}
+			inert={!open || undefined}
 			initial={false}
 			animate={{ height: open ? "auto" : 0 }}
 			transition={motionEnabled ? SPRING : INSTANT}
-			onAnimationComplete={() => {
-				if (!open) setCollapsed(true);
-			}}
 			style={{ overflow: "hidden", ...style }}
 			className="text-sm"
 		>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,11 +1,25 @@
 import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
+import { AnimatePresence, motion } from "motion/react";
 import type * as React from "react";
+import { createContext, useContext } from "react";
 import { Button } from "@/components/ui/button";
 import { useMotionEnabled } from "@/hooks/use-motion";
+import { INSTANT, SPRING_FAST, SPRING_POP } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 
-function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
-	return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+// The dialog is unmounted while closed, so exit animations need `AnimatePresence`
+// to see the `open` state. `AlertDialog` forwards it through context to
+// `AlertDialogContent`, which drives the Base UI popup with `motion.div` via the
+// `render` prop (Base UI is headless) — no CSS keyframes; the motion preference
+// swaps the springs for INSTANT.
+const AlertDialogOpenContext = createContext(false);
+
+function AlertDialog({ open = false, ...props }: AlertDialogPrimitive.Root.Props) {
+	return (
+		<AlertDialogOpenContext.Provider value={open}>
+			<AlertDialogPrimitive.Root data-slot="alert-dialog" open={open} {...props} />
+		</AlertDialogOpenContext.Provider>
+	);
 }
 
 function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
@@ -16,43 +30,61 @@ function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
 	return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
 }
 
-function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdrop.Props) {
-	const motionEnabled = useMotionEnabled();
-	return (
-		<AlertDialogPrimitive.Backdrop
-			data-slot="alert-dialog-overlay"
-			className={cn(
-				"fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-				!motionEnabled && "animate-none!",
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
-
 function AlertDialogContent({
 	className,
 	size = "default",
+	children,
 	...props
 }: AlertDialogPrimitive.Popup.Props & {
 	size?: "default" | "sm";
 }) {
+	const open = useContext(AlertDialogOpenContext);
 	const motionEnabled = useMotionEnabled();
+	// Bouncy pop on the way in; a smooth, non-bouncy settle on the way out so the
+	// exit doesn't feel rubbery.
+	const pop = motionEnabled ? SPRING_POP : INSTANT;
+	const smooth = motionEnabled ? SPRING_FAST : INSTANT;
+
 	return (
-		<AlertDialogPortal>
-			<AlertDialogOverlay />
-			<AlertDialogPrimitive.Popup
-				data-slot="alert-dialog-content"
-				data-size={size}
-				className={cn(
-					"group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-popover p-6 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-					!motionEnabled && "animate-none!",
-					className,
-				)}
-				{...props}
-			/>
-		</AlertDialogPortal>
+		<AnimatePresence>
+			{open && (
+				<AlertDialogPortal keepMounted>
+					<AlertDialogPrimitive.Backdrop
+						data-slot="alert-dialog-overlay"
+						className="fixed inset-0 isolate z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs"
+						render={
+							<motion.div
+								initial={{ opacity: 0 }}
+								animate={{ opacity: 1 }}
+								exit={{ opacity: 0 }}
+								transition={smooth}
+							/>
+						}
+					/>
+					<div className="pointer-events-none fixed inset-0 z-50 grid place-items-center p-4">
+						<AlertDialogPrimitive.Popup
+							data-slot="alert-dialog-content"
+							data-size={size}
+							className={cn(
+								"group/alert-dialog-content pointer-events-auto relative grid w-full gap-6 rounded-xl bg-popover p-6 text-popover-foreground ring-1 ring-foreground/10 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg",
+								className,
+							)}
+							render={
+								<motion.div
+									initial={{ opacity: 0, scale: 0.95 }}
+									animate={{ opacity: 1, scale: 1 }}
+									exit={{ opacity: 0, scale: 0.96, transition: smooth }}
+									transition={pop}
+								/>
+							}
+							{...props}
+						>
+							{children}
+						</AlertDialogPrimitive.Popup>
+					</div>
+				</AlertDialogPortal>
+			)}
+		</AnimatePresence>
 	);
 }
 
@@ -157,7 +189,6 @@ export {
 	AlertDialogFooter,
 	AlertDialogHeader,
 	AlertDialogMedia,
-	AlertDialogOverlay,
 	AlertDialogPortal,
 	AlertDialogTitle,
 	AlertDialogTrigger,

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,36 +1,37 @@
+import { Drawer as DrawerPrimitive } from "@base-ui/react/drawer";
 import type * as React from "react";
-import { Drawer as DrawerPrimitive } from "vaul";
-
 import { useMotionEnabled } from "@/hooks/use-motion";
 import { cn } from "@/lib/utils";
 
-function Drawer({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+// Base UI's drawer is CSS-transition + gesture driven (the swipe updates
+// `--drawer-swipe-*` CSS vars), so — unlike the dialog — it isn't a `motion.div`
+// target. We honor the motion preference by killing the transitions with a class
+// override when it's off, the same way the dialog's CSS variant used to.
+
+function Drawer({ ...props }: DrawerPrimitive.Root.Props) {
 	return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
 }
 
-function DrawerTrigger({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+function DrawerTrigger({ ...props }: DrawerPrimitive.Trigger.Props) {
 	return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
 }
 
-function DrawerPortal({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+function DrawerPortal({ ...props }: DrawerPrimitive.Portal.Props) {
 	return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
 }
 
-function DrawerClose({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+function DrawerClose({ ...props }: DrawerPrimitive.Close.Props) {
 	return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
 }
 
-function DrawerOverlay({
-	className,
-	...props
-}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+function DrawerBackdrop({ className, ...props }: DrawerPrimitive.Backdrop.Props) {
 	const motionEnabled = useMotionEnabled();
 	return (
-		<DrawerPrimitive.Overlay
-			data-slot="drawer-overlay"
+		<DrawerPrimitive.Backdrop
+			data-slot="drawer-backdrop"
 			className={cn(
-				"fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-				!motionEnabled && "animate-none! transition-none!",
+				"fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs transition-opacity duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] data-swiping:duration-0 data-starting-style:opacity-0 data-ending-style:opacity-0",
+				!motionEnabled && "transition-none!",
 				className,
 			)}
 			{...props}
@@ -38,27 +39,25 @@ function DrawerOverlay({
 	);
 }
 
-function DrawerContent({
-	className,
-	children,
-	...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+function DrawerContent({ className, children, ...props }: DrawerPrimitive.Popup.Props) {
 	const motionEnabled = useMotionEnabled();
 	return (
-		<DrawerPortal data-slot="drawer-portal">
-			<DrawerOverlay />
-			<DrawerPrimitive.Content
-				data-slot="drawer-content"
-				className={cn(
-					"group/drawer-content fixed z-50 flex h-auto flex-col bg-popover text-sm text-popover-foreground data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm",
-					!motionEnabled && "transition-none!",
-					className,
-				)}
-				{...props}
-			>
-				<div className="mx-auto mt-4 hidden h-1.5 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
-				{children}
-			</DrawerPrimitive.Content>
+		<DrawerPortal>
+			<DrawerBackdrop />
+			<DrawerPrimitive.Viewport className="fixed inset-0 z-50 flex items-end justify-center">
+				<DrawerPrimitive.Popup
+					data-slot="drawer-content"
+					className={cn(
+						"group/drawer-content relative flex max-h-[80vh] w-full max-w-lg flex-col overflow-y-auto overscroll-contain rounded-t-xl border-t bg-popover pb-4 text-sm text-popover-foreground outline-none touch-auto transform-[translateY(var(--drawer-swipe-movement-y))] transition-transform duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] data-swiping:select-none data-swiping:duration-0 data-starting-style:transform-[translateY(100%)] data-ending-style:transform-[translateY(100%)]",
+						!motionEnabled && "transition-none!",
+						className,
+					)}
+					{...props}
+				>
+					<div className="mx-auto mt-4 h-1.5 w-[100px] shrink-0 rounded-full bg-muted" />
+					<DrawerPrimitive.Content className="w-full">{children}</DrawerPrimitive.Content>
+				</DrawerPrimitive.Popup>
+			</DrawerPrimitive.Viewport>
 		</DrawerPortal>
 	);
 }
@@ -67,10 +66,7 @@ function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
 			data-slot="drawer-header"
-			className={cn(
-				"flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
-				className,
-			)}
+			className={cn("flex flex-col gap-0.5 p-4 text-center md:gap-1.5", className)}
 			{...props}
 		/>
 	);
@@ -86,7 +82,7 @@ function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
 	);
 }
 
-function DrawerTitle({ className, ...props }: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+function DrawerTitle({ className, ...props }: DrawerPrimitive.Title.Props) {
 	return (
 		<DrawerPrimitive.Title
 			data-slot="drawer-title"
@@ -96,10 +92,7 @@ function DrawerTitle({ className, ...props }: React.ComponentProps<typeof Drawer
 	);
 }
 
-function DrawerDescription({
-	className,
-	...props
-}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+function DrawerDescription({ className, ...props }: DrawerPrimitive.Description.Props) {
 	return (
 		<DrawerPrimitive.Description
 			data-slot="drawer-description"
@@ -116,7 +109,6 @@ export {
 	DrawerDescription,
 	DrawerFooter,
 	DrawerHeader,
-	DrawerOverlay,
 	DrawerPortal,
 	DrawerTitle,
 	DrawerTrigger,

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -22,6 +22,17 @@ export const SPRING_FAST: Transition = {
 };
 
 /**
+ * Springy pop for popups that appear at rest (e.g. the photo lightbox): a small
+ * `bounce` lets the scale overshoot ~1 and settle for a slick feel — kept low so
+ * it reads as lively, not rubbery. Not for height/collapse (use `SPRING`).
+ */
+export const SPRING_POP: Transition = {
+	type: "spring",
+	bounce: 0.28,
+	visualDuration: 0.32,
+};
+
+/**
  * Used when motion is disabled (user preference or prefers-reduced-motion):
  * snaps to the target value with no animation.
  */

--- a/src/pages/sitemap-images.xml.ts
+++ b/src/pages/sitemap-images.xml.ts
@@ -1,0 +1,56 @@
+import type { APIRoute } from "astro";
+import type { OptimizedImage } from "@/components/home/archive/archive-images";
+import { getOptimizedImagesByYear } from "@/components/home/archive/archive-optimized";
+import { LOCALES } from "@/i18n/config";
+import { getDictionary } from "@/i18n/dictionary";
+
+// The archive lives on each locale's homepage, but its photos sit inside
+// collapsed accordion panels — hidden markup that image crawlers skip. This
+// image sitemap declares every archive photo (with its localized caption)
+// against the page that hosts it, the channel Google supports for surfacing
+// images that aren't prominently rendered.
+
+const LOCALE_PATH: Record<(typeof LOCALES)[number], string> = { en: "", id: "id/" };
+
+function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&apos;");
+}
+
+function urlEntry(
+	lang: (typeof LOCALES)[number],
+	site: URL,
+	imagesByYear: Record<number, Array<OptimizedImage>>,
+): string {
+	const timeline = getDictionary(lang).archive.timeline;
+	const pageLoc = new URL(LOCALE_PATH[lang], site).href;
+
+	const images = Object.entries(imagesByYear).flatMap(([year, assets]) => {
+		const entry = timeline[year as keyof typeof timeline];
+		return assets.map((image, i) => {
+			const loc = new URL(image.src, site).href;
+			const caption = entry.photoAlts[i] ?? "";
+			return `\t\t<image:image>\n\t\t\t<image:loc>${escapeXml(loc)}</image:loc>${
+				caption ? `\n\t\t\t<image:caption>${escapeXml(caption)}</image:caption>` : ""
+			}\n\t\t</image:image>`;
+		});
+	});
+
+	return `\t<url>\n\t\t<loc>${escapeXml(pageLoc)}</loc>\n${images.join("\n")}\n\t</url>`;
+}
+
+export const GET: APIRoute = async ({ site }) => {
+	if (!site) throw new Error("`site` must be configured to build the image sitemap");
+
+	const imagesByYear = await getOptimizedImagesByYear();
+	const urls = LOCALES.map((lang) => urlEntry(lang, site, imagesByYear)).join("\n");
+	const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">\n${urls}\n</urlset>\n`;
+
+	return new Response(xml, {
+		headers: { "Content-Type": "application/xml" },
+	});
+};


### PR DESCRIPTION
Archive photo work in three parts: make the images indexable by crawlers, serve them at a sane size, and rebuild the photo lightbox on Motion + Base UI (dropping vaul).

## 1. Crawlability
The archive photos render inside collapsed accordion panels, so image crawlers never see them.
- **Image sitemap** — new `sitemap-images.xml` endpoint declares every archive photo (localized caption from the dictionary) against the page that hosts it, advertised in `robots.txt` and filtered out of the page sitemap. This is Google's supported channel for images that aren't prominently rendered.
- **Accordion `inert`** — collapsed panels now use `inert` instead of the `hidden`/`display:none` attribute, so the `<img>` markup stays rendered and crawlable while remaining out of the a11y tree and tab order.

## 2. Image optimization
Astro was copying the full-res originals (e.g. a 948 KB, 2316×3088 source into a ~180 px tile), because the island referenced `.src` directly.
- Archive photos now go through `astro:assets` `getImage` — a `200 / 400 / 800w` webp `srcset`, base capped near the ~364 px display size. `getImage` is server-only, so optimization happens in the `.astro` layer and plain data is passed into the island (and reused for the image sitemap).
- Added intrinsic `width`/`height` on the tiles. Result: up to ~95% smaller on the worst offenders; served HTML references only the optimized variants.

## 3. Lightbox primitives
- **Desktop (AlertDialog)** is now Motion-driven — `AnimatePresence` + `keepMounted` Portal + `render` composing the popup as `motion.div`, with a subtle bounce in (`SPRING_POP`) and a smooth settle out.
- **Mobile (Drawer)** is rebuilt on Base UI's headless drawer (Portal/Viewport/Popup/Content), **dropping the `vaul` dependency**. Base UI's drawer is CSS/gesture-driven, so reduced motion is class-gated there.
- Both respect the motion preference (springs → `INSTANT`, or `transition-none` for the drawer).

## Verification
- `pnpm check` (0 errors) · Biome clean · `pnpm build` passes · no `vaul` in the output bundle.
- Headless Chromium against the production build: desktop dialog + mobile drawer both open with the image and **close/unmount cleanly, zero console errors**; motion-off gate confirmed (`transition-property: none` when off, animates when on).

## Needs a manual pass
- Dev server throws `504 Outdated Optimize Dep` once after the dependency swap until Vite re-optimizes (clear `node_modules/.vite` or reload). Production build is unaffected.
- Swipe-to-dismiss feel and the bounce amount (`SPRING_POP` `bounce: 0.28`) can't be asserted headlessly — worth an eyeball on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)