### PR TITLE
feat(now): add Lanjut resume builder entry with linked repo

### DIFF
--- a/src/components/now/happening-now.tsx
+++ b/src/components/now/happening-now.tsx
@@ -1,3 +1,4 @@
+import { ArrowUpRight } from "lucide-react";
 import { useMotionEnabled } from "@/hooks/use-motion";
 import type { Lang } from "@/i18n/config";
 import { getDictionary } from "@/i18n/dictionary";
@@ -34,6 +35,17 @@ export function HappeningNow({ lang }: { lang: Lang }) {
 						{item.title}
 					</h2>
 					<p className="max-w-2xl pt-1 text-sm text-muted-foreground">{item.description}</p>
+					{"link" in item && (
+						<a
+							href={item.link}
+							target="_blank"
+							rel="noopener"
+							className="inline-flex items-center gap-1 pt-2 text-sm text-muted-foreground hover:underline"
+						>
+							{item.link.replace(/^https?:\/\//, "")}
+							<ArrowUpRight className="size-3" />
+						</a>
+					)}
 				</li>
 			))}
 		</ul>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -207,6 +207,12 @@ export const en = {
 		introLead:
 			"Most sites have an /about page. This is my /now page — a snapshot of what I'm focused on at this point in my life. Inspired by",
 		items: {
+			"2026-07-04": {
+				title: "Building an open source ATS resume builder",
+				description:
+					"Apart from my work at Kolosal AI, I'm building Lanjut — an open source, ATS-friendly resume builder. The code is up on GitHub.",
+				link: "https://github.com/rimzzlabs/lanjut",
+			},
 			"2026-06-30": {
 				title: "Building an interactive canvas with SpacetimeDB",
 				description:

--- a/src/i18n/id.ts
+++ b/src/i18n/id.ts
@@ -206,6 +206,12 @@ export const id: Dictionary = {
 		introLead:
 			"Kebanyakan situs punya halaman /about. Ini halaman /now saya — potret apa yang sedang saya fokuskan pada titik ini dalam hidup saya. Terinspirasi dari",
 		items: {
+			"2026-07-04": {
+				title: "Membangun ATS resume builder open source",
+				description:
+					"Di luar pekerjaan saya di Kolosal AI, saya sedang membangun Lanjut — resume builder open source yang ramah ATS. Kodenya tersedia di GitHub.",
+				link: "https://github.com/rimzzlabs/lanjut",
+			},
 			"2026-06-30": {
 				title: "Membangun kanvas interaktif dengan SpacetimeDB",
 				description:


### PR DESCRIPTION
## Summary

Adds a new Now entry dated 4 July 2026 about building [Lanjut](https://github.com/rimzzlabs/lanjut), an open source ATS-friendly resume builder, alongside the work at Kolosal AI. Added in both locales (EN + ID).

Now entries previously supported only plain text, so the repo URL couldn't be clickable. This adds an optional `link` field to `now.items` and renders it in `HappeningNow` as an anchor (muted text, hover underline, `ArrowUpRight` icon — same treatment as footer links). Entries without a `link` are unaffected.

## Verification

- `pnpm check` — 0 errors; Biome clean on all three files
- `pnpm build` — both `dist/now/index.html` and `dist/id/now/index.html` contain the new entry and the `github.com/rimzzlabs/lanjut` link