### PR TITLE
feat(i18n): add Indonesian note translations and revise id copy

### DIFF
--- a/src/content/notes/id/how-to-setup-husky-nextjs.mdx
+++ b/src/content/notes/id/how-to-setup-husky-nextjs.mdx
@@ -1,0 +1,333 @@
+---
+title: "Cara Setup Husky, Lint Staged, Dan Commitizen Di Project Next.js"
+description: "Coding bukan sekadar menulis baris kode, kita sering harus mengerjakan semuanya secara manual. Jadi kenapa tidak memakai tools yang bisa membantu mencapai tujuan tersebut? Artikel ini akan menunjukkan cara setup Husky, Lint Staged, dan Conventional Commit dengan Next.js"
+publishedAt: "03/23/2022"
+status: "published"
+featured: false
+author: rimzzlabs
+keywords:
+  - husky nextjs
+  - husky lint staged
+  - nextjs husky lint-staged
+  - how to setup husky
+  - how to setup husky lint staged
+  - how to setup nextjs
+  - husky lint staged commitizen
+  - commitizen
+  - commitizen nextjs
+  - commitizen reactjs
+  - conventional commit setup
+  - husky setup
+  - lint staged nextjs
+  - lint staged reactjs
+  - lint staged setup
+  - nextjs reactjs
+  - setup developer experience
+  - setup developer experience nextjs
+relatedPosts:
+  - improving-performance-in-react
+  - jotai-state-manager
+---
+
+## Pendahuluan
+
+Sebagai developer, kita suka bekerja dengan Git, sebuah version control system yang membuat kode kita tetap terlacak dan memastikan tidak ada perubahan yang terlewat untuk di-commit.
+
+Tapi ada satu masalah dengan Git: ketika bekerja dengan banyak developer, kita sering harus melakukan merge terhadap perubahan masing-masing. Di situlah merge conflict muncul. Jika konfliknya memang berasal dari perbedaan logika kode, wajar kita harus mengubahnya lagi. Tapi ada kasus di mana konflik hanya disebabkan oleh perbedaan code style, misalnya single quote vs double quote. Cukup merepotkan, bukan?
+
+### Git Hooks
+
+Seperti banyak Version Control System lain, Git punya cara untuk menjalankan script custom ketika event tertentu terjadi. Ada dua kelompok hook ini: client-side dan server-side.
+
+Client-side hook dipicu oleh operasi seperti commit dan merge, sedangkan server-side hook berjalan pada operasi jaringan seperti menerima push commit. Hook ini bisa dipakai untuk berbagai keperluan.
+
+Misalnya begini: saya punya satu project dengan 2 orang di dalamnya, kami membangun fitur di branch yang berbeda-beda. Suatu saat ketika saya commit, ternyata ada type error di dalam kode dan saya tidak tahu penyebabnya. Solusinya, saya ingin menjalankan linter sebelum commit, sehingga error tersebut bisa diperbaiki lebih dulu sebelum commit benar-benar terjadi.
+
+Tapi melakukannya secara manual tentu merepotkan, jadi saya butuh tool yang bisa menjalankan script linter secara otomatis sebelum commit dibuat.
+
+## Husky
+
+Apa itu [Husky](https://typicode.github.io/husky)? Dari yang saya pahami:
+
+> Husky improves your commits and more 🐶 woof!
+
+Seperti dijelaskan sebelumnya soal Git Hooks, kita bisa memakai hook tersebut untuk menjalankan script custom sebelum action tertentu terjadi. Husky membuat proses ini jauh lebih mudah digunakan dan sangat membantu pekerjaan sehari-hari.
+
+### Fitur
+
+Husky menawarkan beberapa fitur:
+
+- Zero dependencies dan ringan (`6 kB`)
+- Ditenagai oleh fitur Git modern (`core.hooksPath`)
+- Mengikuti best practice [npm](https://docs.npmjs.com/cli/v7/using-npm/scripts#best-practices) dan [yarn](https://yarnpkg.com/advanced/lifecycle-scripts#a-note-about-postinstall) terkait auto install
+- Pesan yang ramah pengguna
+- Instalasi opsional
+- Seperti Husky 4, mendukung:
+  - macOS, Linux, dan Windows
+  - Git GUI
+  - Custom directory
+  - Monorepo
+
+## Lint Staged
+
+[Lint Staged](https://github.com/okonet/lint-staged) menjalankan linter terhadap file yang sudah di-staging di git, agar tidak ada kode buruk 💩 yang lolos masuk ke codebase. Jadi ketika kamu menjalankan perintah berikut, script ini akan berjalan otomatis:
+
+```bash showLineNumbers
+$ git commit
+
+✔ Preparing lint-staged...
+❯ Running tasks for staged files...
+  ❯ packages/frontend/.lintstagedrc.json — 1 file
+    ↓ *.js — no files [SKIPPED]
+    ❯ *.{json,md} — 1 file
+      ⠹ prettier --write
+  ↓ packages/backend/.lintstagedrc.json — 2 files
+    ❯ *.js — 2 files
+      ⠼ eslint --fix
+    ↓ *.{json,md} — no files [SKIPPED]
+◼ Applying modifications from tasks...
+◼ Cleaning up temporary files...
+```
+
+> Linting lebih masuk akal kalau dijalankan sebelum commit dilakukan. Dengan begitu, tidak ada error yang masuk ke repository dan code style tetap terjaga. Tapi menjalankan proses lint pada seluruh project itu lambat, dan hasil lint-nya pun bisa jadi tidak relevan. Pada akhirnya, kamu hanya perlu me-lint file yang akan di-commit saja.
+
+## Conventional Commit Dengan Commitizen
+
+Berkolaborasi dengan developer lain cukup menyenangkan, tapi ketika bekerja dalam tim, kamu harus memastikan kode tetap bersih dan mengikuti aturan tim, di mana beberapa tim menerapkannya lebih ketat dari yang lain. Karena itu, pesan commit kamu juga harus jelas dan mudah dipahami.
+
+Di sinilah kita membutuhkan [Commitizen](https://commitizen-tools.github.io/commitizen/), untuk memastikan pesan commit jelas secara konteks dan mudah dipahami oleh developer lain.
+
+Commitizen sangat membantu saat kamu ingin membuat commit. Alih-alih menulis pesan sendiri, tool ini akan menuntunmu menulis pesan berdasarkan aturan tim dan konteks, seperti `feat`, `fix`, dan `chore`.
+
+Berikut tampilannya saat kamu menjalankan `cz` alih-alih `git commit`. Tool ini akan memunculkan prompt yang membantumu memilih pesan commit:
+
+![Commitizen](https://ik.imagekit.io/mlnzyx/attachment/commitizen_Qkfrd4tze.png?ik-sdk-version=javascript-1.4.3&updatedAt=1648026254029 "Commitizen Prompt on terminal")
+
+> Tip: klik gambar di atas untuk melihatnya lebih jelas
+
+## Setup Project Next.js
+
+Sebelum memakai tools apa pun, kita perlu menginstal Next.js dan membuat project baru. Jalankan perintah berikut di terminal:
+
+```bash
+yarn create next-app my-app
+```
+
+Perintah ini akan membuat project Next.js baru lengkap dengan template default. Kamu bisa mulai mengedit kode di sana, tapi artikel ini tidak membahas cara mengedit kode itu sendiri, jadi kita lewati bagian itu dan lanjut ke tools yang ingin kita gunakan.
+
+## Setup Eslint Dan Prettier
+
+Sebelum lanjut, metode yang saya jelaskan di sini juga memakai 2 tools penting, yaitu [eslint](https://eslint.org/) dan [prettier](https://prettier.io/).
+
+Mari kita setup kedua tools tersebut. Kita akan menginstal prettier dan eslint, lalu menambahkan file konfigurasinya ke dalam project. Jalankan perintah berikut di terminal:
+
+```bash
+yarn add prettier -D && npx eslint --init
+```
+
+Perintah di atas akan menginstal prettier sebagai devDependencies, sekaligus menginisialisasi eslint untuk project kamu. Kamu akan diminta membuat beberapa pilihan tergantung jenis project yang kamu punya. Jika memakai TypeScript, pilih **typescript react**, jika tidak, pilih javascript react.
+
+Eslint akan menginstal dependency yang dibutuhkan lalu membuat file konfigurasi. Jika hasilnya berupa file `.json`, sebaiknya ubah menjadi file `.js` dan sesuaikan kodenya mengikuti format `.js`.
+
+Selanjutnya, buat file baru di root project dengan nama `.prettierrc.js`, lalu tempelkan konfigurasi berikut ke dalamnya:
+
+```js title=".prettierrc.js" showLineNumbers
+const config = {
+  semi: false,
+  tabWidth: 2,
+  printWidth: 120,
+  singleQuote: true,
+  jsxSingleQuote: true,
+  trailingComma: "none",
+  arrowParens: "always",
+  endOfLine: "auto",
+};
+
+module.exports = config;
+```
+
+> Jika sudah familiar, silakan ubah konfigurasi ini sesuai preferensi kamu sendiri
+
+## Setup Husky
+
+Selanjutnya, mari instal Husky sebagai Git Hooks kita dengan menjalankan perintah berikut di terminal:
+
+```bash
+yarn add husky -D
+```
+
+Setelah instalasi selesai, jalankan perintah untuk setup husky:
+
+```bash
+husky install
+```
+
+Perintah ini akan membuat folder baru di root direktori bernama `/.husky`. Buka folder tersebut lalu buat file baru bernama `pre-commit` di dalam direktori `/.husky`, sehingga strukturnya akan menjadi seperti ini:
+
+```bash
+/.husky
+/pre-commit
+|- /_
+|-|
+  |- /.gitignore
+  |- /husky.sh
+```
+
+Di dalam file `pre-commit`, tempelkan kode berikut:
+
+```bash title=".husky/pre-commit" showLineNumbers
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+echo '🏗️👷 Styling your project before committing👷‍♂️🏗️'
+echo 'please be patient, this may take a while...'
+
+# Check ESLint Standards
+yarn lint ||
+(
+    echo '🔨❌ Yoo, you have a problem in your code. Check linter 🔨❌
+          Run yarn lint, add changes and try commit again.';
+    false;
+)
+
+echo '🎉 No error found: committing this now.... ✨🚀🏄‍♂️🍻'
+
+npx lint-staged
+```
+
+Kode di atas akan berjalan di terminal sebelum Git membuat commit. Pertama, dua baris pesan akan dicetak, lalu perintah `yarn lint` dijalankan. Jika perintah tersebut gagal, pesan _*🔨❌ Yoo, you have...*_ akan muncul dan sisa proses langsung dibatalkan karena kode `false` dieksekusi.
+
+Jika linting berhasil dan tidak ada error, pesan sukses akan dicetak lalu script `npx lint-staged` dijalankan untuk memformat kode dengan prettier.
+
+Buat script baru di dalam `package.json` agar perintah ini otomatis berjalan setiap kali project diinstal:
+
+```json {5} title="./package.json" showLineNumbers
+{
+  "name": "app name",
+  "version": "0.0.0",
+  "scripts": {
+    "postinstall": "husky install"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}
+```
+
+## Setup Lint Staged
+
+Selanjutnya kita perlu menginstal dan mengonfigurasi Lint Staged agar linter berjalan sebelum commit. Caranya sangat mudah, cukup jalankan perintah berikut di terminal untuk menginstalnya:
+
+```bash
+yarn add lint-staged -D
+```
+
+Setelah instalasi selesai, mari buat konfigurasi untuk lint-staged. Lint-staged menawarkan beberapa cara konfigurasi:
+
+- Object `lint-staged` di dalam `package.json`
+- File `.lintstagedrc` dalam format JSON atau YAML, atau bisa juga eksplisit dengan ekstensi file:
+  - `.lintstagedrc.json`
+  - `.lintstagedrc.yaml`
+  - `.lintstagedrc.yml`
+
+Di artikel ini saya akan menunjukkan cara memakai object lint-staged di dalam package.json:
+
+```json title="./package.json" {9-12}
+{
+  "name": "app name",
+  "version": "0.0.0",
+  "scripts": {
+    "postinstall": "husky install"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --config ./.prettierrc.js --write"
+    ],
+    "**/*.{css,scss,md,html,json}": [
+      "prettier --config ./.prettierrc.js --write"
+    ]
+  }
+}
+```
+
+## Setup Commitizen
+
+Commitizen membantu merapikan pesan commit. Biasanya ketika saya melakukan perubahan pada kode, saya ingin melacak dengan jelas apa yang sudah saya lakukan.
+
+Cara paling mudah untuk setup Commitizen adalah lewat CLI-nya. Langkah pertama adalah membuat repo kamu **Commitizen friendly**, jadi mari instal CLI Commitizen terlebih dahulu. Kamu bisa menginstalnya secara global atau lokal, tapi saya lebih suka instalasi global. Jalankan perintah berikut di terminal:
+
+```bash
+yarn global add commitizen
+```
+
+Jika memakai npm, kamu bisa menginstalnya dengan perintah berikut:
+
+```bash
+npm install commitizen -g
+```
+
+Selanjutnya, inisialisasi project kamu untuk memakai adapter cz-conventional-changelog dengan mengetik:
+
+```bash
+commitizen init cz-conventional-changelog --save-dev --save-exact
+```
+
+Atau jika memakai Yarn:
+
+```bash
+commitizen init cz-conventional-changelog --yarn --dev --exact
+```
+
+Perintah di atas melakukan tiga hal:
+
+- Menginstal `cz-conventional-changelog adapter`
+- Menyimpannya ke dalam dependencies atau devDependencies di `package.json`
+- Menambahkan key `config.commitizen` ke root `package.json` kamu seperti berikut:
+
+```json {13-17} title="./package.json" showLineNumbers
+{
+  "name": "app name",
+  "version": "0.0.0",
+  "scripts": {
+    "postinstall": "husky install"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --config ./.prettierrc.js --write"
+    ],
+    "**/*.{css,scss,md,html,json}": [
+      "prettier --config ./.prettierrc.js --write"
+    ]
+  },
+  "config": {
+    "commitizen": {
+      "path": "cz-conventional-changelog"
+    }
+  }
+}
+```
+
+Sekarang kamu sudah siap memakai perintah `cz` untuk membuat commit, dan tool ini akan menuntunmu memilih pesan commit yang tepat.
+
+## Ringkasan
+
+Kita sudah sampai di akhir, mari rangkum apa yang sudah dilakukan:
+
+- **Husky**
+
+  Membantu setup Git Hooks dengan lebih mudah.
+
+- **Lint Staged**
+
+  Membantu menjalankan task tertentu sebelum commit dilakukan, memastikan kode tetap bersih dan terformat dengan baik.
+
+- **Commitizen**
+
+  Membantu merapikan pesan commit, memastikan pesan tersebut jelas dan mudah dipahami.
+
+Sekian, semoga artikel ini membantu kamu memulai. Sampai jumpa di artikel berikutnya!

--- a/src/content/notes/id/improving-performance-in-react.mdx
+++ b/src/content/notes/id/improving-performance-in-react.mdx
@@ -1,0 +1,340 @@
+---
+title: "Tingkatkan Performa React Dengan 3 Teknik Ini"
+description: "Aplikasi yang lambat atau tidak responsif bisa membuat pengguna frustrasi dan menyebabkan pengalaman pengguna yang buruk. Di pasar yang kompetitif saat ini, memastikan aplikasimu memberikan pengalaman terbaik bagi pengguna menjadi lebih penting dari sebelumnya."
+publishedAt: "12/25/2022"
+status: "published"
+featured: false
+author: rimzzlabs
+keywords:
+  - improve performance
+  - react
+  - react.js
+  - performance
+  - code-splitting
+  - react app
+  - lazy
+  - loading
+  - lazy loading
+  - react performance
+  - code splitting react app
+  - vitejs
+  - memoization
+  - usememo
+  - usecallback
+  - React.memo
+  - React.useCallback
+  - React.useMemo
+  - memoization in react
+  - improving performance in react app
+relatedPosts:
+  - how-to-setup-husky-nextjs
+  - jotai-state-manager
+---
+
+## Pendahuluan
+
+> Bacaan panjang, silakan duduk santai dan nikmati 🍻.
+
+React.js adalah library JavaScript populer untuk membangun user interface, dikenal karena fleksibilitas dan performanya. Dengan React.js, kamu bisa membuat komponen yang bisa dipakai ulang, sehingga memudahkan pembuatan dan pemeliharaan aplikasi yang kompleks.
+
+> Halo! Saya sarankan kamu mencoba contoh kode langsung sambil membaca artikel ini. Silakan lanjutkan membaca. Semangat ✌️.
+
+React.js dibuat oleh Facebook dan sejak itu menjadi salah satu pilihan paling populer untuk front-end development, berkat kemampuannya menangani aplikasi kompleks dan dinamis dengan mudah.
+
+Di dalam aplikasi React.js, komponen adalah building block yang membentuk user interface. Komponen-komponen ini bisa disusun bersama membentuk hierarki pohon komponen, dengan root komponen mewakili keseluruhan aplikasi.
+
+Ketika state atau props _(singkatan dari properties)_ sebuah komponen berubah, React.js secara efisien memperbarui DOM untuk merefleksikan perubahan tersebut. Ini membuat aplikasi React.js tetap cepat dan responsif, bahkan saat menangani data dalam jumlah besar.
+
+Namun, seiring bertambahnya kompleksitas dan skala aplikasi React.js, developer perlu mengambil langkah untuk mengoptimalkan performanya. Ini termasuk teknik seperti **code-splitting**, yang membantu mengurangi ukuran bundle awal yang dimuat browser, dan **memoization**, yang membantu meningkatkan efisiensi pemanggilan fungsi dengan menyimpan cache hasilnya.
+
+Di artikel ini, kita akan membahas **code-splitting**, memoization dengan `React.memo`, `React.useMemo`, dan `React.useCallback`. Baik kamu baru mengenal React.js maupun developer berpengalaman yang ingin meningkatkan performa aplikasimu, artikel ini cocok untukmu.
+
+## Mengoptimalkan Performa
+
+Dalam membangun aplikasi web, performa adalah hal yang krusial. Aplikasi yang lambat atau tidak responsif bisa membuat pengguna frustrasi dan menyebabkan **user experience** yang buruk. Di pasar yang kompetitif saat ini, memastikan aplikasimu memberikan pengalaman terbaik bagi pengguna menjadi lebih penting dari sebelumnya.
+
+Tapi performa _bukan hanya soal kepuasan pengguna_. Performa juga bisa berdampak langsung pada bisnis. Misalnya, jika aplikasimu terlalu lama untuk dimuat, pengguna mungkin meninggalkannya sebelum sempat melihat apa yang bisa ditawarkan aplikasi tersebut. Ini bisa menyebabkan hilangnya pelanggan dan pendapatan. Sebaliknya, aplikasi yang cepat dan responsif bisa membuat pengguna tetap terlibat dan lebih mungkin kembali lagi.
+
+Performa tetap menjadi pertimbangan penting untuk aplikasi web apa pun. Berikut beberapa alasan kenapa kamu harus peduli dengan performa aplikasi React.js kamu:
+
+- **User Experience:** Aplikasi yang lambat atau tidak responsif bisa membuat pengguna frustrasi, yang bisa menyebabkan mereka meninggalkan aplikasi sepenuhnya. Sebaliknya, aplikasi yang cepat dan mulus bisa meningkatkan pengalaman pengguna secara keseluruhan dan membuat mereka terus kembali.
+
+- **SEO:** Di lanskap digital saat ini, website atau aplikasimu perlu memiliki ranking yang baik di hasil mesin pencari. Salah satu faktor yang mempengaruhi ranking adalah kecepatan loading situsmu. Jika aplikasi React.js kamu lambat dimuat, ini bisa merusak ranking mesin pencari dan menyulitkan pengguna menemukan aplikasimu.
+
+- **Conversion Rates:** Aplikasi yang lambat juga bisa berdampak pada keuntungan bisnismu. Berbagai studi menunjukkan bahwa waktu loading yang lebih cepat bisa menghasilkan conversion rate yang lebih tinggi, artinya lebih banyak pengguna yang melakukan tindakan yang diinginkan (seperti melakukan pembelian).
+
+- **Scalability:** Seiring bertambahnya kompleksitas dan skala aplikasi React.js kamu, penting untuk memastikan aplikasi tersebut mampu menangani beban yang meningkat. Mengoptimalkan performa aplikasimu bisa membantu memastikan aplikasi tetap stabil dan scalable seiring pertumbuhannya.
+
+Singkatnya, mengoptimalkan performa aplikasi React.js kamu penting baik untuk kepuasan pengguna maupun keberhasilan bisnismu. Di bagian selanjutnya, kita akan membahas teknik-teknik lanjutan untuk mencapai hal tersebut.
+
+## Code-Splitting
+
+Code-splitting adalah teknik yang memungkinkan developer memecah kode mereka menjadi bagian atau bundle yang lebih kecil dan mudah dikelola. Bundle-bundle ini kemudian bisa dimuat sesuai kebutuhan, bukan sekaligus saat aplikasi pertama kali dimuat.
+
+Ini bisa membantu meningkatkan performa aplikasi React.js dengan mengurangi ukuran bundle awal yang harus diunduh browser, sehingga aplikasi bisa dimuat lebih cepat.
+
+Code-splitting sangat berguna untuk aplikasi besar dan kompleks yang memiliki banyak kode, karena memungkinkan developer memecah kode menjadi bagian-bagian kecil yang bisa dimuat sesuai kebutuhan. Ini bisa membantu mengurangi ukuran keseluruhan aplikasi, yang bisa meningkatkan performa dan mempermudah pemeliharaan.
+
+Ada beberapa cara untuk menerapkan code-splitting di aplikasi React.js, seperti menggunakan komponen `React.lazy` dan `React.Suspense`, atau menggunakan tool seperti [Vite.js](https://vitejs.dev).
+
+### Suspending Komponen
+
+Untuk menerapkan code splitting di aplikasi React kamu, kamu bisa memakai `React.lazy` dan `React.suspense`.
+
+`React.lazy` memungkinkanmu melakukan dynamic import terhadap sebuah komponen, sehingga komponen tersebut hanya dimuat saat dibutuhkan. Ini dilakukan memakai fungsi `import()`, yang mengembalikan promise yang resolve ke module yang kamu import.
+
+`React.suspense` adalah higher-order component yang bisa kamu pakai untuk membungkus dynamic import di dalam komponen `<Suspense>`. Ini akan menampilkan komponen fallback selagi kode untuk komponen yang di-dynamic-import sedang dimuat.
+
+Berikut contoh cara memakai `React.lazy` dan `React.Suspense` di aplikasimu:
+
+```tsx title="App.tsx" showLineNumbers
+import { Suspense, lazy } from "react";
+
+const MyComponent = lazy(() => import("./MyComponent"));
+
+export default function App() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <MyComponent />
+    </Suspense>
+  );
+}
+```
+
+Pada contoh ini, komponen `MyComponent` tidak akan dimuat sampai dibutuhkan, dan komponen fallback akan ditampilkan selagi kode untuk `MyComponent` sedang dimuat. Ini bisa membantu meningkatkan performa aplikasimu karena hanya memuat kode yang dibutuhkan.
+
+### Bundling Dengan Vite.js
+
+> Untuk membaca lebih lanjut tentang Vite.js, silakan [ikuti tautan ini tentang Vite.js](https://vitejs.dev/guide)
+
+Selain memakai `React.lazy` dan `React.suspense`, cara lain untuk menerapkan code splitting di aplikasi React kamu adalah dengan memakai tool bernama Vite.js sebagai frontend tooling.
+
+Vite.js adalah build tool yang ringan, sederhana, dan cepat, dirancang khusus untuk aplikasi JavaScript modern. Vite.js memakai Rollup di bawahnya, artinya kamu bisa memakai semua teknik code-splitting yang sama seperti yang kamu pakai dengan Rollup di project Vite.js kamu.
+
+Salah satu keuntungan memakai Vite.js untuk code splitting adalah kamu bisa dengan mudah memecah kode menjadi berbagai chunk, termasuk memisahkan kode vendor dari kode kamu sendiri. Ini bisa membantu meningkatkan performa aplikasimu karena hanya memuat kode yang dibutuhkan pada saat tertentu, bukan memuat semuanya sekaligus di awal.
+
+Mari pisahkan kode vendor dari kode kita, lihat kode berikut:
+
+```ts title="vite.config.ts" showLineNumbers
+import { dependencies } from "./package.json";
+
+const exclVendors = ["react", "react-router-dom", "react-dom"];
+function renderChunks(deps: Record<string, string>) {
+  let chunks = {};
+  Object.keys(deps).forEach((key) => {
+    if (exclVendors.includes(key)) return;
+    chunks[key] = [key];
+  });
+  return chunks;
+}
+// https://vitejs.dev/config/
+export default defineConfig({
+  build: {
+    sourcemap: false,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          ...renderChunks(dependencies),
+        },
+      },
+    },
+  },
+});
+```
+
+Pada kode ini, fungsi `renderChunks` dipakai untuk membuat object dengan key untuk setiap dependency, dan value yang berisi nama dependency tersebut. Ini memungkinkanmu membuat chunk untuk setiap dependency, yang kemudian bisa di-code-split.
+
+Kamu mungkin memperhatikan ada array vendor yang dikecualikan di dalam kode tersebut. Array ini dipakai untuk menentukan dependency mana yang tidak boleh dimasukkan ke proses code-splitting.
+
+Dalam kasus ini, array tersebut berisi `react`, `react-router-dom`, dan `react-dom`, yang merupakan dependency inti React yang tidak dimasukkan ke proses code-splitting. Ini karena dependency tersebut kemungkinan besar dipakai di seluruh aplikasimu, sehingga tidak menguntungkan untuk memecahnya menjadi chunk terpisah.
+
+Sementara itu, dependency lainnya ditambahkan ke object `rollupOptions`, yang dipakai untuk mengonfigurasi proses code-splitting. Dependency-dependency ini akan dipecah menjadi chunk terpisah dan dimuat sesuai kebutuhan, bukan sekaligus. Ini bisa membantu meningkatkan performa aplikasimu karena hanya memuat kode yang dibutuhkan pada saat tertentu.
+
+Secara keseluruhan, dengan mengecualikan dependency tertentu dari proses code splitting dan menambahkan sisanya ke object `rollupOptions`, kamu bisa efektif mengatur code splitting di project Vite.js kamu dan meningkatkan performa aplikasi React.js kamu.
+
+Jenis komponen apa yang cocok dipakai dengan `React.lazy`, dan jenis komponen apa yang sebaiknya tidak di-lazy-load?
+
+Ada beberapa jenis komponen yang cocok untuk code-splitting dengan `React.lazy`. Misalnya, jika ada fitur yang hanya dipakai di satu halaman aplikasi, fitur tersebut bisa di-code-split menjadi chunk terpisah yang hanya dimuat ketika pengguna membuka halaman itu.
+
+Berikut beberapa jenis komponen yang cocok untuk code-splitting dengan `React.lazy`:
+
+- Komponen yang hanya dibutuhkan di route atau area tertentu di aplikasi. Misalnya, jika ada fitur yang hanya dipakai di satu halaman aplikasimu, fitur tersebut bisa di-code-split menjadi chunk terpisah yang hanya dimuat ketika pengguna membuka halaman itu.
+- Komponen yang besar atau kompleks, dan mungkin butuh waktu lama untuk dimuat. Memecah komponen ini menjadi chunk yang lebih kecil bisa membantu mengurangi waktu loading awal aplikasimu.
+- Komponen yang jarang dipakai atau hanya dipakai oleh sedikit pengguna. Dalam kasus ini, code-splitting bisa membantu mengurangi ukuran keseluruhan aplikasimu dan meningkatkan performa untuk mayoritas pengguna.
+
+Di sisi lain, beberapa jenis komponen mungkin bukan kandidat yang baik untuk code-splitting dengan `React.lazy`:
+
+- Komponen yang dibutuhkan segera pada saat initial load. Jika sebuah komponen sangat penting untuk render awal aplikasimu, komponen tersebut mungkin bukan kandidat yang baik untuk code-splitting, karena pengguna harus menunggu komponen itu dimuat sebelum aplikasi bisa dipakai.
+- Komponen yang kecil dan sederhana, dan mungkin tidak memberikan manfaat performa yang signifikan jika di-code-split. Dalam kasus ini, akan lebih efisien membiarkan komponen tersebut tetap di bundle utama dan menghindari overhead dari dynamic import.
+
+Secara umum, penting untuk mengevaluasi trade-off code-splitting dengan cermat saat memutuskan komponen mana yang perlu dipecah. Code-splitting bisa menjadi tool yang ampuh untuk meningkatkan performa aplikasi React, tapi penting untuk mempertimbangkan kebutuhan spesifik aplikasimu sebelum menerapkannya.
+
+## Memoization
+
+Memoization adalah teknik yang membantu mempercepat aplikasimu dengan menyimpan hasil dari pemanggilan fungsi yang mahal dan mengembalikannya ketika input yang sama muncul kembali. Ini sangat berguna untuk fungsi yang sering dipanggil dengan argumen yang sama, karena menghemat waktu tanpa perlu menghitung ulang hasilnya setiap kali.
+
+Dalam konteks React, memoization bisa dipakai untuk membuat functional component berjalan lebih efisien. Secara default, React akan me-render ulang functional component setiap kali props atau state komponen berubah. Ini bisa menjadi masalah jika komponen sering dipanggil dengan props yang sama, karena akan menyebabkan re-render yang tidak perlu. Memoization bisa membantu mengatasi masalah ini dengan "mengingat" komponen tersebut dan hanya me-render ulang jika props-nya benar-benar berubah.
+
+Ada beberapa cara memakai memoization di aplikasi React. Salah satunya memakai hook `React.useMemo`, fitur bawaan React yang memungkinkanmu memoize sebuah value. Lalu ada hook `React.useCallback`, fitur bawaan React lainnya, tapi hook ini memoize sebuah fungsi, bukan value. Terakhir, ada `React.memo`, juga fitur bawaan React, tapi bedanya bukan fungsi melainkan _Higher Order Component_ yang memungkinkanmu memoize sebuah komponen.
+
+Memoization ibarat caching di aplikasi React.js kamu. Berikut beberapa alasan kenapa memoization penting di aplikasi React.js:
+
+- **Performa yang lebih baik**: Seperti disebutkan sebelumnya, memoization bisa membantu meningkatkan performa aplikasimu dengan menghindari re-render yang tidak perlu pada functional component. Ini sangat berguna untuk komponen yang sering dipanggil dengan props yang sama, karena bisa menghemat banyak waktu dan resource dengan menghindari perhitungan ulang hasil komponen.
+
+- **User experience yang lebih baik**: Dengan mengoptimalkan performa aplikasimu, kamu bisa meningkatkan pengalaman pengguna secara keseluruhan. Waktu loading yang lebih cepat dan transisi yang lebih mulus antar layar bisa membuat aplikasimu terasa lebih responsif dan menyenangkan untuk dipakai.
+
+- **Kompleksitas yang berkurang**: Memoization juga bisa membantu mengurangi kompleksitas kode dengan memungkinkanmu menulis komponen yang lebih sederhana dan deklaratif. Tanpa memoization, kamu mungkin harus menulis logic yang lebih rumit untuk menghindari re-render yang tidak perlu, yang bisa membuat kodemu lebih sulit dipahami dan dipelihara.
+
+### React.useMemo
+
+Hook useMemo adalah hook bawaan React yang memungkinkanmu memoize sebuah value. Hook ini menerima sebuah fungsi sebagai argumen dan **mengembalikan versi memoized** dari value yang dikembalikan fungsi tersebut.
+
+Value yang di-memoize **hanya dihitung ulang jika salah satu dependency yang tercantum di argumen kedua hook tersebut berubah**. Ini berguna untuk mengoptimalkan performa functional component dengan menghindari perhitungan ulang yang tidak perlu terhadap value yang mahal.
+
+Lihat sintaks dasar hook `React.useMemo` berikut:
+
+```tsx
+const value = useMemo(() => computedExpensiveValue(buzz, fizz), [buzz, fizz]);
+```
+
+Pada contoh ini, fungsi `computedExpensiveValue` dipanggil dengan argumen `buzz` dan `fizz`, dan **hasilnya di-memoize**. Value yang di-memoize **hanya akan dihitung ulang jika nilai `buzz` atau `fizz` berubah**.
+
+Contoh lain pemakaian `React.useMemo` adalah untuk memfilter dan mengurutkan data set yang besar. Misalnya kamu punya daftar produk yang ingin ditampilkan di sebuah komponen, dan kamu ingin memungkinkan pengguna memfilter serta mengurutkan daftar tersebut berdasarkan berbagai kriteria. Kamu bisa memakai hook `useMemo` untuk memoize versi hasil filter dan urutan dari daftar tersebut, seperti ini:
+
+```tsx title="@/components/product-list.tsx" showLineNumbers
+import { useMemo } from "react";
+
+export const ProductList = ({ products, filter, sortBy }) => {
+  // Memoize the filtered and sorted version of the product list
+  const filteredAndSortedProducts = useMemo(() => {
+    // Filter the products based on the filter criteria
+    let filteredProducts = products;
+    if (filter) {
+      filteredProducts = filteredProducts.filter((product) =>
+        product.name.includes(filter),
+      );
+    }
+    // Sort the products based on the sortBy criteria
+    return filteredProducts.sort((a, b) => a[sortBy] > b[sortBy]);
+  }, [products, filter, sortBy]);
+
+  return (
+    <ul>
+      {filteredAndSortedProducts.map((product) => (
+        <li key={product.id}>{product.name}</li>
+      ))}
+    </ul>
+  );
+};
+```
+
+Pada contoh ini, komponen `ProductList` memfilter dan mengurutkan daftar produk berdasarkan props filter dan `sortBy`, lalu menyimpan hasilnya sebagai value yang di-memoize. Ini bisa membantu meningkatkan performa komponen dengan **menghindari perhitungan ulang yang tidak perlu** terhadap daftar yang sudah difilter dan diurutkan setiap kali komponen re-render.
+
+### Jangan useMemo Semua Hal
+
+`React.useMemo` adalah hook yang memungkinkanmu mengoptimalkan performa functional component dengan memoize value yang mahal untuk dihitung. Tapi ada beberapa situasi di mana hook ini bukan pilihan terbaik:
+
+- Jika value yang kamu hitung _sangat sederhana_ atau _murah untuk dihitung_, mungkin tidak sepadan dengan overhead tambahan dari memakai `React.useMemo`. Dalam kasus ini, peningkatan performanya mungkin tidak sebanding dengan kode tambahan yang dibutuhkan.
+
+- Jika value yang kamu hitung hanya dipakai sekali atau beberapa kali saja di dalam komponen, mungkin tidak sepadan dengan overhead tambahan dari memakai `React.useMemo`. Dalam kasus ini, peningkatan performanya mungkin tidak cukup signifikan untuk membenarkan kode tambahan tersebut.
+
+- Jika value yang kamu hitung bergantung pada props yang sangat sering berubah, `React.useMemo` mungkin tidak bisa mengikuti perubahan tersebut dan kamu bisa berakhir dengan data yang basi. Dalam kasus ini, pertimbangkan memakai teknik optimasi lain, seperti `React.useEffect` atau `React.useReducer`, untuk **menghindari perhitungan ulang yang tidak perlu**.
+
+`React.useMemo` adalah cara yang baik untuk meningkatkan performa aplikasi React kamu, kecuali value yang kamu hitung sangat sederhana atau murah untuk dihitung, hanya dipakai beberapa kali di dalam komponen, atau bergantung pada props yang sering berubah. Tapi di kebanyakan kasus lain, `React.useMemo` bisa menjadi cara yang sangat berguna untuk mengoptimalkan performa functional component kamu.
+
+## React.useCallback
+
+Hook `useCallback` adalah hook bawaan React yang memungkinkanmu membuat versi memoized dari sebuah callback function. Hook ini menerima sebuah fungsi dan array dependency sebagai argumen, dan **mengembalikan versi memoized dari fungsi tersebut yang hanya berubah jika salah satu dependency-nya berubah**.
+
+Ini berguna untuk mengoptimalkan performa functional component dengan **menghindari pembuatan ulang** callback function yang tidak perlu.
+
+Lihat sintaks dasar hook `useCallback` berikut:
+
+```tsx showLineNumbers
+const callback = useCallback(() => {
+  doSomething(longitude, latitude);
+}, [longitude, latitude]);
+```
+
+Pada contoh ini, callback function dibuat memakai hook `useCallback`, dan fungsi tersebut **hanya akan dibuat ulang jika nilai `longitude` atau `latitude` berubah**.
+
+Contoh lain pemakaian `React.useCallback` adalah dengan meneruskan callback ke komponen yang berada jauh di dalam hierarki. Jika kamu punya hierarki komponen yang kompleks dan ingin meneruskan callback function ke komponen anak, kamu bisa memakai hook `useCallback` untuk menghindari pembuatan ulang callback function yang tidak perlu. Ini bisa membantu meningkatkan performa aplikasimu dengan menghindari re-render yang tidak perlu pada komponen anak.
+
+Misalnya kamu punya komponen parent yang me-render daftar item, dan setiap item memiliki tombol hapus yang memanggil callback hapus saat diklik. Kamu bisa memakai hook `useCallback` untuk membuat versi memoized dari callback hapus tersebut dan meneruskannya ke komponen anak seperti ini:
+
+```tsx title="@/components/parent-component.tsx" showLineNumbers
+import { useCallback } from "react";
+
+const ParentComponent = ({ items, onDelete }) => {
+  // Create a memoized version of the onDelete callback
+  const handleDelete = useCallback(
+    (itemId) => {
+      onDelete(itemId);
+    },
+    [onDelete],
+  );
+
+  return (
+    <ul>
+      {items.map((item) => (
+        <ChildComponent key={item.id} item={item} onDelete={handleDelete} />
+      ))}
+    </ul>
+  );
+};
+```
+
+Pada contoh ini, komponen fungsi `ParentComponent` me-render daftar komponen ChildComponent dan meneruskan callback function untuk menghapus item ke setiap komponen. Hook `useCallback` dipakai untuk membuat versi memoized dari callback function tersebut, yang membantu meningkatkan performa komponen `ParentComponent` dengan **menghindari pembuatan ulang fungsi yang tidak perlu**. Komponen `ChildComponent` kemudian bisa memakai callback function tersebut untuk menghapus item terkait saat tombol hapus diklik.
+
+Ada beberapa situasi di mana hook ini bukan pilihan terbaik, berikut beberapa alasannya:
+
+- Jika callback function sangat sederhana atau murah untuk dibuat, kemungkinan tidak masuk akal untuk memakai `React.useCallback`. Overhead tambahannya mungkin tidak sepadan dalam kasus ini.
+
+- Jika callback function hanya dipakai beberapa kali di dalam komponen, mungkin tidak sepadan untuk memakai `React.useCallback`. Peningkatan performanya mungkin tidak cukup signifikan dalam kasus ini.
+
+- Jika callback function bergantung pada props yang sangat sering berubah, `React.useCallback` mungkin tidak bisa mengikuti perubahan tersebut dan kamu bisa berakhir dengan fungsi yang basi. Dalam kasus ini, pertimbangkan memakai teknik optimasi lain.
+
+## React.memo
+
+`React.memo` adalah cara untuk mengoptimalkan performa functional component di React dengan **mencegah komponen tersebut re-render secara tidak perlu**. Caranya dengan **"mengingat"** komponen tersebut, artinya komponen hanya akan re-render jika props-nya benar-benar berubah.
+
+Berikut contoh cara memakai `React.memo`:
+
+```tsx title="@/components/my-component.tsx" showLineNumbers
+import { memo } from "react";
+
+const MyComponent = ({ name }) => {
+  console.log("Render MyComponent");
+  return <div>Hello, {name}!</div>;
+};
+
+export default memo(MyComponent);
+```
+
+Pada contoh ini, komponen `MyComponent` me-render sebuah greeting dengan props name. Dengan membungkus komponen tersebut memakai `React.memo`, kamu memberitahu React untuk hanya me-render ulang komponen jika props name berubah. Ini bisa membantu meningkatkan performa aplikasimu dengan menghindari re-render yang tidak perlu pada komponen tersebut.
+
+Kamu bisa memakai `React.memo` untuk mengoptimalkan performa functional component apa pun yang tidak perlu re-render setiap kali props-nya berubah. Ini cara yang sederhana dan efektif untuk meningkatkan performa aplikasi React kamu.
+
+Pada dasarnya, `React.memo` adalah cara untuk mengoptimalkan performa functional component dengan **menghindari re-render yang tidak perlu**. Tapi ada beberapa situasi di mana ini bukan pilihan terbaik:
+
+- Jika komponen tidak memiliki perhitungan atau props yang mahal _(misalnya `object` atau `array` yang besar)_, mungkin tidak banyak manfaat performa dari memakai `React.memo`. Dalam kasus ini, overhead dari memakai `React.memo` bisa lebih lambat dibanding sekadar me-render ulang komponen.
+
+- Jika komponen memiliki banyak state atau props, memakai `React.memo` justru bisa membuat komponen lebih lambat, karena HOC ini harus membandingkan seluruh state dan props di setiap update. Dalam kasus ini, akan lebih efisien memakai hook `React.useMemo` atau hook `React.useReducer` untuk mengoptimalkan performa komponen.
+
+- Jika komponen di-update sangat sering _(misalnya setiap tick dari sebuah timer)_, memakai `React.memo` mungkin tidak efisien, karena _HOC_ tersebut harus membandingkan props sebelumnya dan sekarang di setiap update. Dalam kasus ini, akan lebih efisien memakai class component atau hook `React.useReducer` untuk mengoptimalkan performa komponen.
+
+Semoga ini membantu memberi gambaran kapan sebaiknya kamu memakai atau tidak memakai `React.memo` untuk mengoptimalkan performa.
+
+## Penutup
+
+Kita sudah membahas beberapa teknik untuk mengoptimalkan performa aplikasi React.js, termasuk memoization, code-splitting, dan lainnya. Dengan memakai teknik-teknik ini, kamu bisa meningkatkan performa aplikasimu dan memberikan pengalaman yang lebih baik bagi penggunamu.
+
+Berikut beberapa tips tambahan untuk mengoptimalkan performa aplikasi React.js kamu:
+
+- Pakai ekstensi browser [React Developer Tools](https://beta.reactjs.org/learn/react-developer-tools "react dev tools browser extension link") untuk melakukan profiling aplikasimu dan mengidentifikasi bottleneck performa.
+
+- Pertimbangkan memakai tool performance monitoring seperti [LogRocket](https://logrocket.com/ "log rocket official website") untuk melacak performa aplikasimu seiring waktu.
+
+- Pertimbangkan memakai state management seperti [Jotai](https://jotai.org "Jotai official website") atau [Zustand](https://docs.pmnd.rs/zustand/getting-started/introduction "Zustand official documentation website") untuk mengelola state aplikasimu dengan mudah.
+
+Terima kasih sudah membaca artikel ini! Semoga bermanfaat. Sampai jumpa di artikel berikutnya!

--- a/src/content/notes/id/jotai-recipes.mdx
+++ b/src/content/notes/id/jotai-recipes.mdx
@@ -1,0 +1,337 @@
+---
+title: "Jotai Recipes Yang Sering Saya Pakai Di Project"
+description: "Untuk membaca dan mengubah state di aplikasi kita dengan Jotai, kita perlu memakai paradigma bernama Recipes. Sekarang mari lihat bagaimana kita bisa memanfaatkan konsep tersebut untuk membaca dan mengubah state dengan Jotai"
+publishedAt: "09/30/2023"
+status: "published"
+featured: true
+author: rimzzlabs
+keywords:
+  - react
+  - jotai
+  - hooks
+  - jotai recipes
+  - reactjs
+  - state management
+  - state manager
+relatedPosts:
+  - jotai-state-manager
+  - improving-performance-in-react
+---
+
+## Pendahuluan
+
+Jotai memakai pendekatan atomik untuk global state management di React. Dengan mengombinasikan atom, render dioptimalkan secara otomatis berdasarkan dependency antar atom.
+
+Ini menyelesaikan masalah re-render berlebih pada React context, menghilangkan kebutuhan memoization, dan memberikan developer experience yang mirip signals sambil tetap mempertahankan **_model pemrograman deklaratif_**.
+
+> Jika belum tahu tentang Jotai, ada [artikel tentang jotai](/notes/jotai-state-manager) yang menjelaskannya, silakan baca.
+
+Untuk memperbarui state dengan Jotai, cukup pakai `setter` bawaan Jotai seperti ini:
+
+```tsx showLineNumbers title="app.tsx"
+import { atom, useAtom } from "jotai";
+
+const atomFruit = atom("mango");
+
+export default function App() {
+  const [fruit, setFruit] = useAtom(atomFruit);
+
+  return <button onClick={() => setFruit("orange")}>{fruit}</button>;
+}
+```
+
+Penggunaan dasar Jotai, cukup sederhana.
+
+## Derived Value
+
+Sebelum membahas apa itu _recipes_ di Jotai, perlu dipahami dulu konsep derived atau computed value.
+
+Derived atau computed value adalah nilai yang diperoleh dari nilai lain lewat logika, transformasi, atau perhitungan tertentu.
+
+Dalam pemrograman, derived atau computed value sering dipakai untuk menyederhanakan kode, mengenkapsulasi logika, dan membuat manipulasi data berdasarkan nilai yang sudah ada menjadi lebih praktis.
+
+```tsx title="App.tsx" showLineNumbers
+export default function App() {
+  const { user } = useUser();
+  const isUserAdmin = user.role === "admin";
+
+  if (isUserAdmin) {
+    return <p>You are admin</p>;
+  }
+
+  return <p>Just a normal user</p>;
+}
+```
+
+Pada contoh di atas, dicek apakah user adalah admin atau bukan. Jika admin, komponen me-render **"You are admin"**, jika bukan, komponen me-render **"Just a normal user"**.
+
+Kondisi untuk me-render UI berbeda ke client memakai derived value `isUserAdmin`.
+
+Derived value sudah dipakai di sini.
+
+## Derived Atoms
+
+Lanjut ke derived atoms. Derived atoms konsepnya sama seperti sebelumnya. Perlu dilihat dulu nilai sebelumnya, lalu diproses dengan logika atau perhitungan tertentu.
+
+```ts title="@/atoms.ts" showLineNumbers
+import { atom } from "jotai";
+
+type TUserRole = "admin" | "user";
+type TUser = {
+  name: string;
+  role: Role;
+};
+
+const userAtom = atom<TUser>({ name: "Rizki", role: "user" });
+
+const isUserAdminAtom = atom((get) => get(userAtom).role === "admin");
+```
+
+Contoh di atas menunjukkan cara membuat derived value dari atom sebelumnya, mirip dengan yang ditulis sebelumnya memakai `React.useState`.
+
+Di Jotai, ini disebut recipes. Atom bisa dikomposisikan ke atom lain, atau atom baru bisa dibuat berdasarkan atom sebelumnya untuk menghasilkan nilai atau atom baru.
+
+Jotai memungkinkan pembuatan derived value ini dengan pendekatan deklaratif tanpa perlu mengelola relasi state yang kompleks secara eksplisit.
+
+## Recipes
+
+Recipes pada dasarnya adalah derived atoms. Derived atoms biasanya terdiri dari dua prinsip.
+
+Atom `read-only` menerima atom lain sebagai input dan mengubah nilainya lewat perhitungan yang dilakukan oleh sebuah fungsi. Nilai yang berubah ini bisa dipakai untuk menandai hasil komputasi atau modifikasi dari nilai atom asli sebagai derived value.
+
+Atom `write-only` berfungsi menerima nilai baru lewat mekanisme penulisan, seperti `callback`. Nilai baru ini kemudian bisa dipakai untuk memicu action tertentu atau memperbarui atom di dalam atom `write-only` tersebut.
+
+Sekarang konsep ini sudah dipahami, mari buat beberapa recipes.
+
+### 0. Compose Recipes
+
+Composing atom adalah cara mentransformasi atom lewat beberapa pemanggilan fungsi. Nilai yang dikembalikan harus bisa diprediksi dan tidak memiliki side effect.
+
+```ts title="@/atoms/compose.ts" showLineNumbers
+import type { PrimitiveAtom } from "jotai";
+
+type ComposeAtomFn<T> = (value: PrimitiveAtom<T>) => PrimitiveAtom<T>;
+
+export function composePrimitiveAtom<T>(...fns: Array<ComposeAtomFn<T>>) {
+  return (value: PrimitiveAtom<T>) => {
+    return fns.reduce((currentValue, fun) => fun(currentValue), value);
+  };
+}
+```
+
+### 1. Boolean Recipes
+
+Switch. Semua orang butuh boolean value, jadi mari buat boolean recipes.
+
+Biasanya boolean value dikelola dengan React.useState untuk menangani state open atau closed, seperti sidebar atau dialog. Tapi bagaimana jika ini bisa dikemas dengan baik memakai Jotai?
+
+```ts title="@/atoms/boolean.ts" showLineNumbers
+import type { PrimitiveAtom } from "jotai";
+
+export function openAtom(boolAtom: PrimitiveAtom<boolean>) {
+  return atom(null, (_, set) => set(boolAtom, true));
+}
+
+export function closeAtom(boolAtom: PrimitiveAtom<boolean>) {
+  return atom(null, (_, set) => set(boolAtom, false));
+}
+
+export function toggleAtom(boolAtom: PrimitiveAtom<boolean>) {
+  return atom(null, (get, set) => set(boolAtom, !get(boolAtom)));
+}
+```
+
+Dengan snippet tersebut, handler untuk mengelola state `open/closed` bisa dibuat.
+
+```ts title="@/atoms/sidebar.ts" showLineNumbers
+import { openAtom, closeAtom, toggleAtom } from "@/atoms/boolean";
+
+import { atom } from "jotai";
+
+export const sidebarAtom = atom(false);
+export const openSidebarAtom = openAtom(sidebarAtom);
+export const closeSidebarAtom = closeAtom(sidebarAtom);
+export const toggleSidebarAtom = toggleAtom(sidebarAtom);
+```
+
+Penjelasan kode di atas: `openSidebarAtom`, `closeSidebarAtom`, dan `toggleSidebarAtom` adalah atom `write-only`, artinya ini adalah handler untuk mengubah `sidebarAtom`, dengan gaya Jotai.
+
+Sekarang lihat cara memakai atom-atom tersebut.
+
+Pada komponen sidebar, komponen ini bisa mengamati nilai `sidebarAtom` dan me-render UI sesuai nilainya. Komponen ini juga bisa menutup sidebar itu sendiri.
+
+```tsx title="@/components/sidebar.tsx" showLineNumbers
+import { sidebarAtom, closeSidebarAtom } from "@/atoms/sidebar";
+
+import { Drawer } from "@mantine/core";
+import { useAtomValue, useSetAtom } from "jotai";
+
+export function Sidebar() {
+  const isSidebarOpen = useAtomValue(sidebarAtom);
+  const closeSidebar = useSetAtom(closeSidebarAtom);
+
+  return <Drawer opened={isSidebarOpen} onClose={closeSidebar} />;
+}
+```
+
+Lalu, pada komponen tombol yang memicu state `open/closed` sidebar, tombol tersebut mungkin diletakkan di komponen `<Header />`.
+
+```tsx title="@/components/header.tsx" showLineNumbers
+import { openSidebarAtom } from "@/atoms/sidebar";
+
+import { useSetAtom } from "jotai";
+import { MenuIcon } from "lucide-react";
+
+export function Header() {
+  const openSidebar = useSetAtom(openSidebarAtom);
+  return (
+    <header>
+      // other content might be here
+      <button onClick={openSidebar}>
+        <MenuIcon />
+      </button>
+    </header>
+  );
+}
+```
+
+### 2. String Recipes
+
+String recipes biasanya berupa atom `read-only`. String atom diambil lalu ditransformasi menjadi nilai string baru.
+
+Ini sangat membantu ketika bekerja dengan string value, misalnya mengubah string menjadi lowercase, [encoding string ke URI component](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent "Encoding URI Component"), dan sebagainya.
+
+```ts title="@/atoms/string.ts" showLineNumbers
+import type { PrimitiveAtom } from "jotai";
+
+export function upperCaseAtom(stringAtom: PrimitiveAtom<string>) {
+  return atom((get) => get(stringAtom).toUpperCase());
+}
+
+export function lowerCaseAtom(stringAtom: PrimitiveAtom<string>) {
+  return atom((get) => get(stringAtom).toUpperCase());
+}
+```
+
+Encoding string ke URI component.
+
+```ts title="@/atoms/string.ts" showLineNumbers
+import type { PrimitiveAtom } from "jotai";
+
+export function encodeURIAtom(stringAtom: PrimitiveAtom<string>) {
+  return atom((get) => encodeURIComponent(get(stringAtom)));
+}
+```
+
+### 3. Number Recipes
+
+Memanipulasi angka dengan atom sangat mudah. Mulai dari matematika dasar.
+
+```ts title="@/atoms/number.ts" showLineNumbers
+import type { PrimitiveAtom } from "jotai";
+
+export function addAtom(numberAtom: PrimitiveAtom<number>) {
+  return atom((get) => get(numberAtom) + 1);
+}
+export function multiplyAtom(numberAtom: PrimitiveAtom<number>) {
+  return atom((get) => get(numberAtom) * 2);
+}
+export function divideAtom(numberAtom: PrimitiveAtom<number>) {
+  return atom((get) => get(numberAtom) / 2);
+}
+export function minusAtom(numberAtom: PrimitiveAtom<number>) {
+  return atom((get) => get(numberAtom) - 1);
+}
+```
+
+Selanjutnya, angka bisa ditransformasi menjadi nilai yang terformat dengan baik, misalnya memformat angka menjadi mata uang.
+
+```ts title="@/atoms/number.ts" showLineNumbers
+import type { PrimitiveAtom } from "jotai";
+
+export function formatNumberAtom(numberAtom: PrimitiveAtom<number>) {
+  return atom((get) => {
+    const fmt = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+    });
+    return fmt.format(get(numberAtom));
+  });
+}
+```
+
+### 4. Array Recipes
+
+Mulai dengan array recipes dasar. Ada array berisi daftar object, dan array tersebut harus difilter berdasarkan input pengguna.
+
+```ts title="@/atoms/array.ts" showLineNumbers
+import { atom } from "jotai";
+
+export const inputAtom = atom("");
+export const clearInputAtom = composeAtom(
+  lowerCaseAtom,
+  noSpaceStringAtom,
+)(inputAtom);
+export const foodsAtom = atom([]);
+export const filteredFoodsAtom = atom((get) => {
+  const search = get(clearInputAtom);
+  const foods = get(foodsAtom);
+
+  if (search === "") return foods;
+  return foods.filter((food) => {
+    return food.name
+      .toLowerCase()
+      .replace(/\s+/g, "")
+      .includes(search.toLowerCase().replace(/\s+/g, ""));
+  });
+});
+```
+
+Dengan begitu, `filteredFoodsAtom` akan memfilter `foodsAtom` berdasarkan nilai `inputAtom` yang diberikan pengguna.
+
+Fungsi murni untuk membersihkan string juga bisa dibuat.
+
+```ts title="@/util/clearstring"
+export const clearString = (s: string) => s.toLowerCase().replace(/\s+/g, "");
+```
+
+Sekarang, mari refactor `filteredFoodsAtom`.
+
+```ts {12-16} title="@/atoms.ts" showLineNumbers
+import { clearString } from "@/utils/clearString";
+
+import { atom } from "jotai";
+
+export const inputAtom = atom("");
+export const foodsAtom = atom([]);
+export const filteredFoodsAtom = atom((get) => {
+  const search = get(inputAtom);
+  const foods = get(foodsAtom);
+
+  if (search === "") return foods;
+  return foods.filter((food) => {
+    const clearSearch = clearString(search);
+    const clearName = clearString(food.name);
+    return clearName.includes(clearSearch);
+  });
+});
+```
+
+Contoh lain adalah mengurutkan array. Array recipes di Jotai sama seperti cara deklaratif biasa untuk mengubah data.
+
+Mengurutkan array atom mudah, sama seperti contoh sebelumnya, cukup diurutkan.
+
+```ts title="@/atoms.ts" showLineNumbers
+import { compareDesc } from "date-fns";
+import { atom } from "jotai";
+
+export const postAtoms = atom([]);
+
+export const latestPostAtoms = atom((get) => {
+  const posts = get(postAtoms);
+
+  return posts.slice(0).sort((a, b) => compareDesc(a, b));
+});
+```
+
+Itu semua recipes yang bisa dijelaskan di sini. Kemungkinan ada recipes lain yang pernah dipakai namun tidak teringat saat ini. Mungkin akan dibahas di artikel lain.

--- a/src/content/notes/id/jotai-state-manager.mdx
+++ b/src/content/notes/id/jotai-state-manager.mdx
@@ -1,0 +1,271 @@
+---
+title: "Jotai, state manager yang elegan untuk developer React"
+description: "Ketika membahas state manager, kata pertama yang mungkin terlintas adalah Redux, tapi kali ini mari kita bahas library state manager lain, memperkenalkan Jotai."
+publishedAt: "07/08/2022"
+status: "published"
+featured: true
+author: rimzzlabs
+keywords:
+  - react
+  - hooks
+  - jotai hooks
+  - state mangement
+  - react state management
+  - jotai
+  - jotai state manager
+  - jotai react
+  - jotai state
+  - state
+  - primitive state
+  - primitive state management
+relatedPosts:
+  - jotai-recipes
+---
+
+## Pendahuluan
+
+Jotai adalah state manager yang luar biasa untuk React. **Tidak ada re-render tambahan**, state berada di dalam React, dan kamu mendapatkan manfaat penuh dari suspense dan concurrent features. Jotai bisa diskalakan mulai dari sekadar pengganti `React.useState` hingga aplikasi skala besar dengan kebutuhan kompleks.
+
+> Jotai memakai pendekatan bottom-up untuk state management React dengan model atomik yang terinspirasi dari Recoil. State dibangun dengan mengombinasikan atom, dan render dioptimalkan berdasarkan dependency antar atom. Ini menyelesaikan masalah re-render berlebih pada React context dan menghilangkan kebutuhan teknik memoization.
+
+Dulu, saya mulai belajar Frontend Web Development, dan ada banyak sekali yang bisa dipelajari. Salah satu topik terpenting dalam Frontend development adalah state management.
+
+## Memakai Jotai
+
+Di React, saya bisa mendeklarasikan state dengan `useState`.
+
+```tsx
+const [count, setCount] = useState(0);
+```
+
+Masalahnya, ketika aplikasi saya semakin besar, state tersebut harus diteruskan lewat props komponen. Di sinilah `React context` bisa membantu.
+
+Tapi React context bukan solusi yang _luar biasa_ menurut saya. Saya harus membungkus komponen di dalam provider-nya, yang mungkin sudah kamu kenal sebagai **Provider Hell**. React context juga membuat komponen saya re-render setiap kali state berubah.
+
+Jotai di sisi lain terasa seperti useState. Saya tidak perlu membungkus aplikasi dengan Provider, dan Jotai juga memakai pendekatan atomik, pendekatan yang belakangan sudah saya terapkan di banyak hal _(komponen, style, service, dan lainnya)_.
+
+### Mendeklarasikan State di File Store
+
+Di Jotai, saya bisa mendeklarasikan state aplikasi dengan atom.
+
+```ts title="@/store/atom.ts" showLineNumbers
+import { atom } from "jotai";
+
+type User = {
+  username: string;
+  gender: "male" | "female";
+  website: string;
+};
+
+export const userAtom = atom<User | null>(null);
+```
+
+Lalu saya bisa memakai state tersebut di komponen saya.
+
+```tsx showLineNumbers
+import { userAtom } from "@/store/atom";
+
+import { useAtom } from "jotai";
+
+const [user, setUser] = useAtom(userAtom);
+```
+
+Variabel user berisi data user, atau `null` jika tidak ada user yang login. Lalu apa fungsi `setUser`? setUser sama seperti `setState` di React, fungsi untuk mengubah state.
+
+Sama seperti setState React, setUser bisa menerima fungsi atau state baru. Saya bisa mengganti state dengan state baru, seperti ini.
+
+```tsx showLineNumbers
+import { userAtom } from "@/store/atom";
+
+import { useAtom } from "jotai";
+
+const [user, setUser] = useAtom(userAtom);
+
+// replace with newer state
+const updateUser = () =>
+  setUser({ name: "Foo", gender: "male", website: "foo.com" });
+```
+
+Atau mungkin saya hanya ingin mengubah properti tertentu saja. Dalam konteks ini, saya sudah mendeklarasikan **type User** sebelumnya, yaitu object berisi properti **name**, **gender**, dan **website**.
+
+```tsx showLineNumbers
+import { userAtom } from "@/store/atom";
+
+import { useAtom } from "jotai";
+
+const [user, setUser] = useAtom(userAtom);
+
+// modify only name property
+const updateUser = () =>
+  setUser((prevState) => ({ ...prevState, name: "FooBizz" }));
+```
+
+Pada fungsi `updateUser`, saya mengubah properti name menjadi **FooBizz**. Itulah penggunaan dasar Jotai.
+
+Terlihat kan? Persis seperti useState biasa, dan saya juga bisa memakai state User ini di komponen lain, cukup praktis😎.
+
+### Persistent State
+
+Kadang ketika saya refresh browser, state aplikasi saya juga ikut ter-reset, padahal saya ingin state tersebut tetap tersimpan. Solusinya adalah persistent state.
+
+Jotai dilengkapi berbagai utilitas siap pakai, misalnya `atomWithStorage` yang tidak hanya menyimpan state saya tapi juga menyimpannya ke localStorage. Ini disebut persistent state karena state tersimpan di localStorage, dan setiap kali saya mengubah state, localStorage-nya juga ikut diperbarui.
+
+Ini sangat berguna untuk state yang perlu disimpan di localStorage, seperti **Theme**.
+
+```tsx {2,9,13-14} title="@/store/atom.ts" showLineNumbers
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+type User = {
+  username: string;
+  gender: "male" | "female";
+  website: string;
+};
+type Theme = "dark" | "light";
+
+export const userAtom = atom<User | null>(null);
+
+// atomWithStorage(localStorage key, initial value)
+export const themeAtom = atomWithStorage<Theme>("theme", "light");
+```
+
+Saya meng-export atom state baru dengan utilitas `atomWithStorage()`. Fungsi ini menerima 3 argumen, dua argumen pertama wajib, argumen terakhir opsional. Argumen pertama adalah key localStorage, argumen kedua adalah nilai awal untuk state tersebut.
+
+Lalu bagaimana cara memakai state ini? Sama seperti sebelumnya, saya bisa membaca dan mengubah state ini persis seperti useState biasa.
+
+```tsx showLineNumbers
+import { themeAtom } from "@/store/atom";
+
+import { useAtom } from "jotai";
+
+const [theme, setTheme] = useAtom(themeAtom);
+```
+
+## Perbandingan Dengan Library Lain
+
+Mari bandingkan Jotai dengan library lain. Perbandingan ini berdasarkan website resmi Jotai.
+
+### Jotai vs Zustand
+
+Jotai mirip Recoil. Sedangkan [Zustand](https://github.com/pmndrs/zustand "Zustand Repository") mirip Redux.
+
+Perbedaan utamanya ada pada model state. Zustand memakai single store (meskipun kamu bisa membuat beberapa store terpisah), sedangkan Jotai terdiri dari atom-atom primitif yang bisa dikomposisikan bersama. Dalam hal ini, ini soal mental model dalam pemrograman.
+
+Jotai bisa jadi pengganti useState+useContext. Alih-alih membuat banyak context, atom-atom ini berbagi satu context besar.
+
+Zustand adalah external store, dan hook-nya berfungsi menghubungkan dunia luar dengan dunia React.
+
+#### Kapan Harus Beralih
+
+- Jika kamu butuh pengganti useState+useContext, Jotai cocok dipakai.
+- Jika kamu ingin mengubah state dari luar React, Zustand lebih baik.
+- Jika code splitting penting bagimu, Jotai akan bekerja dengan baik.
+- Jika kamu lebih suka Redux devtools, Zustand pilihan yang tepat.
+- Jika kamu ingin memanfaatkan Suspense, Jotai adalah pilihannya.
+
+### Apa Bedanya Jotai Dengan Recoil?
+
+#### Developer
+
+- Jotai dikembangkan secara kolektif oleh beberapa developer di organisasi Poimandres (dulu bernama react-spring).
+- Recoil dikembangkan oleh tim di Facebook.
+
+#### Basis
+
+- Jotai berfokus pada API primitif agar mudah dipelajari, dan bersifat unopinionated. (Filosofi yang sama dengan Zustand)
+- Recoil full-featured untuk aplikasi besar dengan kebutuhan kompleks.
+
+#### Perbedaan Teknis
+
+- Jotai bergantung pada referential identity dari object atom.
+- Recoil bergantung pada string key dari atom.
+
+#### Kapan Memakai Yang Mana
+
+- Jika kamu ingin belajar hal baru, keduanya sama-sama bisa dipakai.
+- Jika kamu suka Zustand, Jotai juga akan terasa menyenangkan.
+- Jika aplikasimu sangat membutuhkan state serialization (menyimpan state ke storage, server, atau URL), Recoil punya fitur yang bagus untuk itu.
+- Jika kamu butuh alternatif React Context, Jotai punya fitur yang cukup.
+- Jika kamu ingin membuat library baru, Jotai bisa memberi primitif yang baik sebagai referensi.
+- Selain itu, keduanya cukup mirip dari segi tujuan umum dan teknik dasarnya.
+
+## Memakainya Dengan React
+
+Saya bisa menyimpan state aplikasi di setiap komponen, tapi saya juga bisa membuat store di file terpisah. Saya lebih suka membuat file baru di dalam folder store, contohnya seperti ini.
+
+```tsx title="@/store/atom.ts" showLineNumbers
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+type Theme = "light" | "dark";
+type User = {
+  name: string;
+  gender: "male" | "female";
+  website: string;
+};
+
+export const userAtom = atom<User | null>(null);
+
+export const themeAtom = atomWithStorage<Theme>("theme", "light");
+```
+
+### Membaca dan Mengubah State
+
+Saya bisa membaca dan mengubah state di setiap komponen seperti ini.
+
+```tsx title="@/components/DarkModeToggle.tsx" showLineNumbers
+import * as atoms from "@/store/atom";
+
+import { useAtom } from "atom";
+
+export default function DarkModeToggle() {
+  const [theme, setTheme] = useAtom(atoms.themeAtom);
+
+  const toggleTheme = setTheme((prev) => (prev === "light" ? "dark" : "light"));
+
+  return <button onClick={toggleTheme}>Current theme is {theme}</button>;
+}
+```
+
+Tapi saya lebih suka membuat custom hooks. Contohnya, untuk mengelola state theme, saya bisa membuat custom hooks untuk berpindah antara dark mode dan light mode.
+
+```tsx title="@/hooks/useDarkMode.ts" showLineNumbers
+import * as atoms from "@/store";
+
+import { useAtom } from "jotai";
+import { useEffect } from "react";
+
+const useDarkMode = () => {
+  const [theme, setTheme] = useAtom(atoms.themeAtom);
+
+  const toggleTheme = () =>
+    setTheme((prev) => (prev === "light" ? "dark" : "light"));
+
+  useEffect(() => {
+    document.documentElement.className = theme;
+    document.documentElement.style.colorScheme = theme;
+  }, [theme]);
+
+  return { theme, toggleTheme };
+};
+
+export default useDarkMode;
+```
+
+Lalu saya bisa merefaktor komponen **DarkModeToggle** di atas menjadi seperti ini:
+
+```tsx {4,6} title="@/components/DarkModeToggle.tsx" showLineNumbers
+import useDarkMode from "@/hooks/useDarkMode";
+
+export default function DarkModeToggle() {
+  const { theme, toggleTheme } = useDarkMode();
+
+  return <button onClick={toggleTheme}>Current theme is {theme}</button>;
+}
+```
+
+Terlihat kan, sangat simpel. Kamu juga bisa membaca dokumentasi lengkap Jotai [di sini](https://jotai.org "Jotai official website").
+
+Konsep inti dan referensi API-nya sangat mudah dipelajari. Cek juga [kursus gratis](https://egghead.io/courses/manage-application-state-with-jotai-atoms-2c3a29f0 "Jotai free course") Jotai ini.
+
+Sekian, terima kasih sudah membaca blog ini, semoga kamu mendapat wawasan lebih tentang Jotai setelah membaca artikel ini. Sampai jumpa di artikel berikutnya👋.

--- a/src/i18n/id.ts
+++ b/src/i18n/id.ts
@@ -10,39 +10,39 @@ export const id: Dictionary = {
 	nav: {
 		home: "Beranda",
 		notes: "Catatan",
-		now: "Saat Ini",
+		now: "Now",
 		dragToMove: "Geser untuk memindahkan",
 		hideDock: "Sembunyikan dock",
 		pages: "Halaman",
 		availablePages: "Halaman Tersedia",
 		preferences: "Preferensi",
 		theme: { label: "Tema", system: "Sistem", light: "Terang", dark: "Gelap" },
-		animations: { label: "Animasi", system: "Sistem", on: "Aktif", off: "Nonaktif" },
+		animations: { label: "Animasi", system: "Sistem", on: "Aktif", off: "Mati" },
 		language: { label: "Bahasa", en: "Inggris", id: "Indonesia" },
 		connect: { trigger: "Hubungi saya", scheduleCall: "Jadwalkan panggilan", resume: "Résumé" },
 	},
 
 	footer: {
-		connect: "Terhubung",
+		connect: "Berteman",
 		resource: "Sumber",
 		resume: "Résumé",
-		sourceCode: "Source Code",
+		sourceCode: "Kode Sumber",
 	},
 
 	homeSeo: {
 		title: "Rizki Citra, Software Engineer",
 		description:
-			"Situs pribadi Rizki Citra, software engineer yang membangun produk web dan AI yang cepat serta menyenangkan — plus catatan seputar frontend.",
+			"Situs pribadi Rizki Citra, software engineer yang membangun produk yang intuitif; yang cepat serta menyenangkan — plus catatan seputar perangkat lunak.",
 	},
 
 	hero: {
 		srName: "Rizki Citra,",
-		titleLead: "Seorang Software Engineer. Merancang UI yang menyenangkan.",
+		titleLead: "Seorang Insinyur Prangkat Lunak. Pengembang UI Intuitif.",
 		srUi: "",
 		titleUi: "",
 		srWhy: "Kenapa rekayasa perangkat lunak? ",
 		p1: "Rekayasa perangkat lunak memungkinkan saya menciptakan solusi inovatif yang selaras dengan nilai-nilai saya dan memberi dampak yang berarti.",
-		p2: "Perpaduan antara struktur, pemecahan masalah, dan evolusi yang terus berlanjut membuat saya tetap terlibat dan bertumbuh.",
+		p2: "Perpaduan antara struktur, pemecahan masalah, dan evolusi yang terus berlanjut membuat saya tetap aktif dan tumbuh.",
 		talk: "Mari Bicara",
 		talkSr: "(Memungkinkan Anda menjadwalkan pertemuan dengan Rizki di cal.com)",
 		resume: "Résumé",
@@ -72,7 +72,7 @@ export const id: Dictionary = {
 				title: "Frontend Developer",
 				period: "Apr 2022 - Feb 2024",
 				summary:
-					"Membangun aplikasi React dan Next.js yang cepat dan aksesibel untuk klien lokal maupun internasional.",
+					"Membangun aplikasi Web yang cepat dan intuitif untuk klien lokal maupun internasional.",
 			},
 			"skyshi-intern": {
 				title: "Frontend Developer Intern",
@@ -85,8 +85,8 @@ export const id: Dictionary = {
 	skill: {
 		heading: "Keahlian",
 		headingSr: "",
-		p1: "Tools datang dan pergi, dan sesekali sesuatu yang baru menjanjikan untuk membuat keahlian ini usang. Saya belajar untuk tidak meremehkannya.",
-		p2: "Yang membuat saya terus maju adalah rasa ingin tahu—mendalami yang penting sambil tetap cukup luas untuk beradaptasi, serta kebiasaan bertumbuh bersama apa pun yang datang berikutnya.",
+		p1: "Tools datang dan pergi, dan sesekali sesuatu yang baru membuat keahlian lama usang. Saya belajar untuk tidak terlalu terpaku pada itu.",
+		p2: "Yang membuat saya terus tumbuh adalah rasa ingin tahu — mendalami hal yang penting sambil tetap cukup leluasa untuk beradaptasi, serta kebiasaan bertumbuh apa pun yang akan datang kedepannya.",
 		domains: {
 			Frontend: "Frontend",
 			Backend: "Backend",
@@ -99,7 +99,7 @@ export const id: Dictionary = {
 		heading: "Catatan",
 		headingSr: "Baca ",
 		intro:
-			"Beberapa hal yang saya tulis saat membangun untuk web — dan apa yang saya pelajari di sepanjang jalan.",
+			"Beberapa hal yang saya pelajari kadang saya tulis disini. Walaupun kadang tidak sempat untuk menulis semuanya.",
 		readAll: "Baca semua catatan",
 	},
 
@@ -107,7 +107,7 @@ export const id: Dictionary = {
 		heading: "Arsip",
 		headingSr: "Perjalanan Saya di Rekayasa Perangkat Lunak - ",
 		intro:
-			"Saya memulai perjalanan rekayasa perangkat lunak pada 2019, dan sejak itu saya selalu bersemangat menciptakan karya yang berarti. Tapi masih banyak yang bisa dikenang.",
+			"Saya memulai perjalanan di software pada tahun 2019, dan sejak itu saya selalu ingin menciptakan karya yang berarti. Tapi masih banyak yang bisa dikenang.",
 		timeline: {
 			"2026": {
 				title: "Sekarang",
@@ -120,19 +120,19 @@ export const id: Dictionary = {
 			"2025": {
 				title: "Kolosal AI",
 				descriptions: [
-					"Sekitar November saya bergabung dengan Kolosal AI dan keluar dari dunia kripto dan web3 menuju sesuatu yang baru: kecerdasan buatan. Lompatan lagi, menukar bidang yang sudah saya kuasai dengan yang bergerak pada kecepatan yang sama sekali berbeda.",
-					"Minggu-minggu pertama adalah soal menemukan pijakan bersama tim yang benar-benar hebat, di ruang yang sebelumnya hanya saya amati dari luar. Cepat terasa seperti tempat yang saya harapkan. Lebih lanjut lain kali.",
+					"Sekitar bulan November, saya bergabung dengan Kolosal AI, menuju sesuatu yang baru: Akal Imitasi atau AI. Sebuah lompatan (lagi), menukar bidang yang sudah saya kuasai dengan yang bergerak pada kecepatan informasi yang sangat berbeda.",
+					"Minggu-minggu pertama adalah soal menemukan sesuatu yang searah bersama tim yang benar-benar hebat.",
 				],
 				photoAlts: [],
 			},
 			"2024": {
 				title: "Bitwyre",
 				descriptions: [
-					"Saya tertarik pada kripto, web3, dan trading sejak akhir 2023, banyak bertanya kepada teman yang sudah lama berkecimpung di bidang itu. Pada Februari 2024 saya meninggalkan Skyshi Digital Indonesia untuk mencari sesuatu yang baru.",
-					"Keesokan harinya, teman yang sama mengenalkan saya ke Bitwyre, perusahaan kripto, web3, dan trading. Saya langsung melamar, berwawancara dengan CTO dan CEO mereka, dan bergabung dengan tim Engineering sebagai Software Engineer (Frontend). Minat pribadi diam-diam menjadi profesi.",
-					"Bitwyre adalah dunia yang berbeda, dengan rekan dari Kanada, AS, India, Eropa, dan lainnya. Bahasa Inggris adalah bahasa ketiga saya, tapi itu tak pernah menghalangi kami membangun bersama lintas zona waktu.",
-					"Agustus itu kami terbang ke Coinfest Asia di Bali, sepekan yang memadukan konferensi dengan hackathon internal kecil di sebuah vila. Sama-sama soal koneksi baru, ide segar, dan bukti bahwa saya bisa mengikuti laju kripto.",
-					"Menjelang akhir 2024 saya juga lulus, menutup babak tiga tahun kuliah. Bukan kampus terbesar atau paling bergengsi, tapi memberi saya fondasi untuk berkembang dan keyakinan untuk terus maju.",
+					"Sejak 2023 lalu, saya sebenarnya sudah tertarik pada kripto, web3, dan trading, saya selalu banyak bertanya kepada teman yang sudah lama berkecimpung di bidang itu. Pada Februari 2024 saya meninggalkan Skyshi Digital Indonesia untuk mencari sesuatu yang baru dibidang software.",
+					"Keesokan harinya, teman saya mengenalkan saya ke Bitwyre, perusahaan kripto, web3, dan trading. Saya langsung melamar, interview dengan CTO dan CEO mereka, dan bergabung dengan tim Engineering sebagai Software Engineer (Frontend).",
+					"Bitwyre adalah dunia yang berbeda, dengan rekan dari Kanada, AS, India, Eropa, dan lainnya. Bahasa Inggris adalah bahasa ketiga saya, tapi itu tidak pernah menghalangi proses saya dalam membangun produk bersama dengan lintas zona waktu.",
+					"Pada bulan Agustus itu kami terbang ke Coinfest Asia di Bali, event yang memadukan konferensi dengan hackathon internal kecil di sebuah vila.",
+					"Menjelang akhir 2024 saya juga lulus dari kuliah di AMIK Serang, menutup babak perkuliahan. Bukan kampus terbesar atau paling bergengsi, tapi memberi saya fondasi untuk berkembang dan keyakinan untuk terus maju.",
 				],
 				photoAlts: [
 					"Festival pass Rizki untuk Coinfest Asia",
@@ -146,9 +146,9 @@ export const id: Dictionary = {
 			"2023": {
 				title: "Work-Life Balance",
 				descriptions: [
-					"Saya terus membangun sebagai Frontend Developer di Skyshi. Yang paling menonjol adalah moladinfinance.com untuk Moladin, dirilis dalam sekitar lima minggu, diikuti serangkaian proyek klien yang terikat NDA.",
-					"Di sela itu, saya membangun ulang PC rakitan saya bagian demi bagian. Setelah setahun hanya dengan laptop, kembali ke setup yang layak dengan layar lebih besar dan ergonomi lebih baik terasa seperti kemewahan.",
-					"Saya menyeimbangkan pekerjaan penuh waktu, kuliah, dan sedikit freelance Facebook bersama teman, menyelesaikan proyek-proyek itu dalam tiga bulan tanpa ada yang terbengkalai. Mengingatnya kembali, saya heran betapa banyak yang muat dalam setahun.",
+					"Saya terus bekerja sebagai Frontend Developer di Skyshi. Yang paling menonjol adalah moladinfinance.com untuk Moladin, dirilis sekitar lima minggu setelah commit pertama, diikuti serangkaian proyek klien yang terikat NDA.",
+					"Di sela itu, saya membangun ulang PC rakitan saya secara bertahap. Setelah setahun hanya dengan laptop, kembali ke setup yang layak dengan layar lebih besar dan ergonomi terasa seperti kemewahan.",
+					"Saya menyeimbangkan pekerjaan penuh waktu, kuliah, dan sedikit freelance Facebook bersama teman, menyelesaikan proyek-proyek itu dalam tiga bulan tanpa ada yang terbengkalai. Mengingatnya kembali, saya pun heran betapa banyak yang terjadi hanya dalam setahun.",
 				],
 				photoAlts: [
 					"Komponen rakitan PC kedua Rizki",
@@ -160,26 +160,26 @@ export const id: Dictionary = {
 			"2022": {
 				title: "Kuliah + Full Time",
 				descriptions: [
-					"Akhir Desember 2021 saya diterima sebagai intern di Skyshi Digital Indonesia, sebuah studio di Gamping, Yogyakarta. Kami bekerja sepenuhnya remote, kebiasaan masa pandemi yang dipertahankan perusahaan.",
-					"Minggu-minggu pertama menegangkan tanpa pengalaman profesional sama sekali, tapi saya cepat menemukan ritme, ikut berkontribusi pada gethired.id, platform internal untuk melatih keterampilan siap kerja.",
-					"Tiga bulan kemudian, mereka mempekerjakan saya penuh waktu sebagai Frontend Developer dan memindahkan saya ke proyek eksternal yang sering terikat NDA. Dari intern menjadi karyawan tetap adalah tonggak karier pertama saya, diraih sambil tetap mengikuti kuliah.",
+					"Akhir Desember 2021 saya diterima sebagai magang di Skyshi Digital Indonesia, sebuah perusahaan software yang berlokasikan di Gamping, Yogyakarta. Kami bekerja sepenuhnya remote, karena sudah menjadi kebiasaan pasca pandemi.",
+					"Minggu-minggu pertama menegangkan tanpa pengalaman profesional sama sekali, tapi saya cepat menemukan ritme team, ikut berkontribusi pada gethired.id, platform internal untuk melatih keterampilan siap kerja.",
+					"Tiga bulan kemudian, mereka mempekerjakan saya penuh waktu sebagai Frontend Developer dan memindahkan saya ke proyek eksternal yang sering terikat NDA. Dari magang menjadi karyawan tetap adalah tonggak karier pertama saya, diraih sambil mengikuti perkuliahan karyawan.",
 				],
 				photoAlts: ["Setup laptop Rizki di kafe dengan es kopi", "Potret Rizki bekerja dari kafe"],
 			},
 			"2021": {
 				title: "Akademik",
 				descriptions: [
-					"Ini tahun saya mulai serius dengan software. Masih dalam pembatasan pandemi, saya mendalami dasar-dasar HTML, CSS, dan JavaScript lewat belajar mandiri dan apa pun yang bisa saya temukan online.",
-					"Pada Mei celahnya jelas: pengetahuan tanpa pengalaman formal menyulitkan untuk diterima kerja. Maka saya bersandar pada struktur, dan akhir 2021 saya diterima di Diploma Manajemen Informatika.",
-					"Di sela kuliah saya terus merilis proyek-proyek kecil agar tetap tajam. Setahun disiplin yang meletakkan fondasi bagi semua yang datang setelahnya.",
+					"Ini tahun saya mulai serius dengan software. Keadaan waktu itu masih pandemi, saya mendalami dasar-dasar HTML, CSS, dan JavaScript lewat belajar mandiri dan apa pun yang bisa saya temukan online.",
+					"Pada Mei waktu itu jelas: pengetahuan tanpa pengalaman formal ternyata menyulitkan untuk diterima kerja. Maka saya ikut pada struktur, dan akhir 2021 saya diterima di AMIK Serang, perguruan tinggi tingkat D3.",
+					"Di sela kuliah, saya terus merilis proyek-proyek kecil agar tetap mengasah skill. Setahun disiplin yang mengasah fondasi bagi hal yang akan datang setelahnya.",
 				],
 				photoAlts: ["Swafoto Rizki, jaket masih basah usai hujan", "Laptop pertama Rizki"],
 			},
 			"2020": {
 				title: "Pandemi",
 				descriptions: [
-					"Setahun ke dalam pandemi, rumah menjadi ruang kelas. Saya di tahun terakhir SMA, gelisah dan ingin melakukan sesuatu dengan waktu saya.",
-					"Maka saya mulai mengambil pekerjaan freelance kecil di sekitar kampung untuk sedikit uang. Pertengahan 2020 saya cukup menabung untuk mulai membeli komponen PC, satu per satu, kapan pun saya mampu membeli yang berikutnya.",
+					"Sudah sekitar satu tahun sejak pandemi, rumah menjadi ruang kelas pribadi. di tahun terakhir saya ketika SMK, Saya banyak menghabiskan waktu didepan komputer.",
+					"Disisi lain saya juga mengambil pekerjaan sampingan dan pekerjaan kecil-kecilan demi bisa makan dan menghidupi keseharian saya.",
 				],
 				photoAlts: [
 					"Sebuah keyboard dan mouse",
@@ -190,7 +190,7 @@ export const id: Dictionary = {
 			"2019": {
 				title: "Kala Itu",
 				descriptions: [
-					"Mengingatnya kembali, ini tahun-tahun emas. Bahkan saat pandemi mulai merayap, ini salah satu masa paling membentuk yang pernah saya alami. Saya belajar Rekayasa Perangkat Lunak di SMKN 8 Pandeglang, dan di sanalah membangun software pertama kali terasa klik.",
+					"Mengingatnya kembali, ini tahun-tahun yang indah. Bahkan saat pandemi mulai merayap, ini salah satu masa paling membentuk yang pernah saya alami. Saya belajar Rekayasa Perangkat Lunak di SMKN 8 Pandeglang, dan di sanalah membangun software pertama kali terasa menyenangkan.",
 					"Tantangannya, kurikulum tertinggal bertahun-tahun dari yang dipakai industri, jadi saya belajar sisanya sendiri dari YouTube dan sumber gratis online, membangun kebiasaan belajar mandiri yang membawa saya sampai sekarang.",
 				],
 				photoAlts: ["Suasana ruang kelas", "Laboratorium komputer di masa itu"],
@@ -201,15 +201,15 @@ export const id: Dictionary = {
 	now: {
 		seoTitle: "Saat Ini",
 		seoDescription:
-			"Kebanyakan situs punya halaman /about. Ini halaman /now saya — potret apa yang sedang saya fokuskan pada titik ini dalam hidup saya. Terinspirasi dari nownownow.com.",
+			"Kebanyakan situs punya halaman /about. Ini halaman /now saya, potret apa yang sedang saya fokuskan pada titik ini dalam hidup saya. Terinspirasi dari nownownow.com.",
 		heading: "Apa yang Sedang Saya Kerjakan",
 		introLead:
 			"Kebanyakan situs punya halaman /about. Ini halaman /now saya — potret apa yang sedang saya fokuskan pada titik ini dalam hidup saya. Terinspirasi dari",
 		items: {
 			"2026-07-04": {
-				title: "Membangun ATS resume builder open source",
+				title: "Membangun ATS resume builder sumber terbuka",
 				description:
-					"Di luar pekerjaan saya di Kolosal AI, saya sedang membangun Lanjut — resume builder open source yang ramah ATS. Kodenya tersedia di GitHub.",
+					"Di luar pekerjaan saya di Kolosal AI, saya sedang membangun Lanjut — resume builder sumber terbuka yang ramah sistem ATS. Kodenya tersedia di GitHub.",
 				link: "https://github.com/rimzzlabs/lanjut",
 			},
 			"2026-06-30": {
@@ -229,7 +229,7 @@ export const id: Dictionary = {
 		seoTitle: "Catatan",
 		title: "Catatan",
 		description:
-			"Catatan tentang apa yang saya pelajari dan bagaimana saya mempelajarinya sebagai frontend software engineer — pemecahan masalah, pembahasan teknis mendalam, dan sesekali resep praktis.",
+			"Catatan tentang apa yang saya pelajari dan bagaimana saya mempelajarinya sebagai insinyur — problem solving, pembahasan teknis mendalam, dan sesekali resep praktis.",
 		publishedOn: "Diterbitkan pada",
 		writtenBy: "Ditulis oleh",
 		onThisPage: "Di halaman ini",


### PR DESCRIPTION
## Summary
- Add Indonesian translations for four notes: husky/lint-staged/commitizen setup, jotai recipes, jotai state manager, and improving React performance (removes the `id/.gitkeep` placeholder now that the folder has content)
- Revise Indonesian UI copy in `src/i18n/id.ts` across nav, footer, hero, skill, archive timeline, /now, and notes strings for a more natural tone

## Notes
- The React performance translation was originally sitting at the notes collection root, where `parseNoteId` would treat it as the English entry and shadow the real `en/` note — moved it into `src/content/notes/id/`
- `pnpm check` passes (0 errors); `pnpm lint` failures are all in generated `.astro/` and `dist/` output, unrelated to this change