### PR TITLE
feat(notes): Introducing Lanjut post (en+id) and external link handling

### DIFF
--- a/src/components/notes/note-article.astro
+++ b/src/components/notes/note-article.astro
@@ -1,5 +1,6 @@
 ---
 import { getEntry, render } from "astro:content";
+import NoteLink from "@/components/notes/note-link.astro";
 import { NotesToc } from "@/components/notes/notes-toc";
 import AppLayout from "@/components/shared/app-layout.astro";
 import Seo from "@/components/shared/seo.astro";
@@ -10,9 +11,9 @@ import { dateToISO, formatDate } from "@/lib/date";
 import type { Note } from "@/lib/notes";
 
 interface Props {
-	lang: Lang;
-	note: Note;
-	translated: boolean;
+  lang: Lang;
+  note: Note;
+  translated: boolean;
 }
 
 const { lang, note, translated } = Astro.props;
@@ -38,7 +39,7 @@ const authorName = author?.data.fullName ?? note.data.author.id;
   <div class="relative">
     <header class="container-fluid pt-12 pb-6 lg:pt-24 lg:pb-12">
       <h1
-        class="text-4xl leading-none font-bold tracking-tight text-balance pb-8 sm:text-5xl lg:pb-16 lg:text-7xl"
+        class="text-4xl leading-none font-bold tracking-tight text-pretty pb-8 sm:text-5xl lg:pb-16 lg:text-7xl"
       >
         {title}
       </h1>
@@ -52,7 +53,10 @@ const authorName = author?.data.fullName ?? note.data.author.id;
         <div class="h-px w-4 bg-muted-foreground"></div>
 
         <div class="inline-flex items-center gap-x-2 text-sm font-medium">
-          <span><span class="max-md:sr-only">{t.writtenBy}</span> {authorName}</span>
+          <span
+            ><span class="max-md:sr-only">{t.writtenBy}{" "}</span>
+            {authorName}</span
+          >
         </div>
       </div>
 
@@ -77,7 +81,7 @@ const authorName = author?.data.fullName ?? note.data.author.id;
   >
     <NotesToc client:load headings={headings} label={t.onThisPage} />
     <article class="prose prose-stone flex-1 dark:prose-invert">
-      <Content />
+      <Content components={{ a: NoteLink }} />
     </article>
   </section>
 </AppLayout>

--- a/src/components/notes/note-link.astro
+++ b/src/components/notes/note-link.astro
@@ -1,0 +1,26 @@
+---
+import type { HTMLAttributes } from "astro/types";
+import { ArrowUpRight } from "lucide-react";
+
+type Props = HTMLAttributes<"a">;
+
+const { href: _href, ...rest } = Astro.props;
+const isExternal = typeof _href === "string" && _href.startsWith("https://");
+const href = isExternal ? `${_href}?utm_source=rimzzlabs.com` : _href;
+---
+
+{
+  isExternal ? (
+    <a {href} target="_blank" rel="noopener" {...rest}>
+      <slot />
+      <ArrowUpRight
+        className="inline size-3.5 align-[-0.125em]"
+        aria-hidden="true"
+      />
+    </a>
+  ) : (
+    <a {href} {...rest}>
+      <slot />
+    </a>
+  )
+}

--- a/src/content/notes/en/introducing-lanjut.mdx
+++ b/src/content/notes/en/introducing-lanjut.mdx
@@ -1,0 +1,188 @@
+---
+title: "Introducing Lanjut. ATS-Friendly Resume Builder"
+description: "ATS-Friendly resume has become one of industry's standard for modern days. But many people find difficulty to create it, so I ship Lanjut. An ATS-Friendly resume builder."
+publishedAt: "06/07/2026"
+status: "draft"
+featured: true
+author: rimzzlabs
+keywords:
+  - ATS Resume Builder
+  - ATS Resume
+  - rimzzlabs ATS Resume Builder
+  - Free ATS Resume Builder
+  - Rizki Citra
+  - Local ATS Resume Builder
+---
+
+ATS-Friendly resume has become one of industry's standard for most company in modern days. But many people find difficulty to create it, especially in Indonesia.
+
+In software engineering, we always rely on information, as it is one of the element of Software. But it's not just it, the information also must provide clarity.
+
+That's what resume do, it must provide clear information about the candidate, both their skills and their background. So companies could match their culture with this candidate.
+
+## Before ATS-Friendly
+
+Let me remind you how applying for a job in Indonesia looked like, not so long ago.
+
+You go to the photocopy shop and buy a _brown folder_. Inside it: a _**handwritten application letter**_, your _**CV**_, a legalized copy of your _**ijazah**_ (a certificate of completing academic), _**SKCK**_(Certificate of Good Conduct) from the police, _**kartu kuning**_(Job Seeker Card) from the local office, and a **_3x4 photo with red background_**. Then you bring the folder to a job fair, or you hand it directly to the security guard at the company's front gate.
+
+Some of those papers even expire. If you don't get hired within a few months, you queue at the police office again.
+
+Then everything moved online. Email, [Jobstreet](https://jobstreet.com), [LinkedIn](https://linkedin.com). It sounds like progress, and it is. But now one job posting can receive hundreds or thousands of applicants. No human reads all of that. So companies let software read it first, and that software is called an ATS, Applicant Tracking System.
+
+The bureaucracy never really disappeared. It just changed form. The gatekeeper used to be paperwork. Now the gatekeeper is a parser.
+
+## The Ghosting
+
+You send your resume. One week, nothing. One month, nothing. Not even a rejection email.
+
+_We_ call it _ghosting_, but most of the time nobody actually decided to ignore you. Your resume just never reached a human. The ATS tried to extract your name, your experience, your skills into its database, and it failed halfway.
+
+I've seen this happen with the popular templates. Two columns, icons for the phone number, a skill bar chart. It looks great to us. But a parser reads text in a linear order, so the two columns get mixed together, and your work experience ends up glued to your hobbies. The system marks you as incomplete, and you never learn why.
+
+That's the cruel part. You did the work, you had the skills, and you got filtered out by a formatting problem you couldn't see.
+
+## Culture in Company
+
+Why is there **"culture"** in a company? And why does each company see this differently?
+
+A company is just people working together for years. Over time they build habits: how they make decisions, how they handle mistakes, how fast they move. That accumulation is the culture. A three-person startup and a fifty-year-old bank can hire for the exact same role and still look for very different people.
+
+So when a company reads your resume, they're not only checking if you can do the job. They're guessing whether you can work the way they work. That's why the same resume can be rejected in one place and celebrated in another.
+
+### Should I Fit-in?
+
+Honestly? Not always.
+
+Culture fit works in both directions. If a company rejects you because of how they read your background, maybe you also just avoided a place where you would be miserable. A rejection is not always a judgment of your skill. Sometimes it's just a mismatch.
+
+But here's what I believe: the matching should fail for the right reason. It should fail because you and the company genuinely don't fit, not because a parser scrambled your resume. You deserve to be rejected by a human, not by a bug.
+
+## Why I Build Lanjut
+
+So I looked at the existing tools, and I didn't like what I found.
+
+The popular resume builders usually do one of two things. They lock the ATS-safe templates behind a subscription, or they give you free templates that look beautiful and parse terribly. Either way you lose. And almost all of them store your resume on their servers, which means your career history, your phone number, your address, lives in someone else's database.
+
+Think about who needs a resume builder the most: someone who doesn't have a job yet. Charging them monthly for the privilege of applying to jobs felt wrong to me.
+
+So I built Lanjut. The name is an Indonesian word that means **"continue"**, which is conveniently also what **"resume"** means.
+
+### Philosophy
+
+Lanjut stands on three ideas.
+
+First, structure is locked, presentation is free. You cannot add tables, columns, or floating text boxes, because those break parsing. But typography, spacing, color, that's all yours. The constraint is not a limitation, it's the whole point. Every design decision that could hurt your parseability is simply not available to make.
+
+Second, your data is yours. Everything lives in your browser's local storage. There is no account, no sign up, no server that ever sees your resume content. Close the tab, come back tomorrow, it's still there. On your machine, nowhere else.
+
+Third, clarity over decoration. A resume is information, and information must provide clarity. Everything else is negotiable.
+
+## How I build Lanjut
+
+I built it in a strict order, and the order mattered.
+
+Data schema and storage first. Then the state layer on top of it. Then the **editing experience**. Then, and only then, the visual themes. Export came last, together **with validation**.
+
+Why this order? Because the whole promise of **Lanjut** is that **presentation can never corrupt structure**. If I had started from the pretty templates, the structure would have bent to serve the visuals. By building the data layer first, **the templates had no choice but to respect it**.
+
+### Lanjut Architecture
+
+The stack is [Next.js](https://nextjs.org) with the **App Router**, deployed on [Cloudflare](https://cloudflare.com) through [open-next](https://opennext.js.org). But Cloudflare only serves the app; **no resume data ever touches a server function or API route**.
+
+State lives in [zustand](https://zustand.docs.pmnd.rs/learn/getting-started/introduction), and every change syncs to [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) with a _debounce_. That's the entire persistence story. No **database bill**, **no backup service**, and **no leak surface**.
+
+The rich text fields use [TipTap](https://tiptap.dev), but with a **deliberately** tiny extension set: **bold**, **italic**, **bullet list**, **ordered list**, **link**. That's it. If a formatting option could confuse a parser, it doesn't exist in the editor.
+
+There are **six templates**, and all of them render the exact same **linear block sequence**. Switching templates changes fonts and spacing, never the reading order. The document shape is versioned too, with a **forward-only migration ladder**, and every document gets snapshotted before migration. If a migration can't parse your data, it keeps the original and does nothing. Your resume is never blanked by an update.
+
+### The Structure
+
+This is how the codebase looks like. I trimmed it to the important parts:
+
+```text
+src/
+├── app/[locale]/            # routes; the editor lives under /platform
+├── components/
+│   ├── editor/              # the editing experience
+│   │   ├── rich-text/       # TipTap, with the tiny extension set
+│   │   ├── templates/       # the six templates
+│   │   ├── docx/ pdf/       # export renderers
+│   │   └── editor-sections/ # one folder per resume section
+│   ├── platform/            # the library: your resumes.
+│   └── ui/                  # shadcn primitives
+├── hooks/                   # use-resume-document, etc.
+├── i18n/                    # English and Indonesian
+└── lib/
+    ├── resume/              # the document: types, factory, migrations
+    ├── db/                  # IndexedDB: schema, repository
+    ├── store/               # zustand stores + debounced persistence
+    └── forms/               # validation schemas
+```
+
+The most important rule here is the **dependency direction**. `lib/resume` defines what a resume _is_, it doesn't know anything about storage or [React](https://react.dev). `lib/db` knows how to save that document, but it doesn't know anything about the UI. `lib/store` sits on top of both, and it's the only layer the components can talk to. Templates and export renderers live in `components`, at the very end of the chain. They can read the document, but they can never change what a document is.
+
+And if you read the tree from bottom to top, it's the same build order I mentioned before. Document, storage, state, editor, templates, and export at the very end. So the promise of **presentation can never corrupt structure** is not just words in this post. It's literally the folder structure.
+
+### How The State Lives
+
+Your resume lives in two places. In memory with [zustand](https://zustand.docs.pmnd.rs/learn/getting-started/introduction) while the tab is open, and in [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) when it's not. The whole job of the persistence layer is to keep these two in sync.
+
+Every edit goes through one function in the store. It clones the open document, applies your change, updates the UI right away, and then _schedules_ a write instead of writing directly:
+
+```ts
+updateOpen(recipe) {
+  const draft = structuredClone(get().open)
+  recipe(draft)
+  draft.updatedAt = new Date().toISOString()
+  set({ open: draft })
+  scheduleOpenResumePersist() // the only bridge to disk
+}
+```
+
+The bridge is just one [debounced](https://developer.mozilla.org/en-US/docs/Glossary/Debounce) write. If you type fast, all of those keystrokes collapse into **one** IndexedDB `put`, around 500ms after you stop typing:
+
+```ts
+const controlled = F.makeControlledDebounce(() => void persistOpenNow(), {
+  delay: 500,
+  leading: false,
+});
+```
+
+But [debounce](https://developer.mozilla.org/en-US/docs/Glossary/Debounce) alone is dangerous. What if you close the tab 400ms after your last keystroke? That's why the pending write gets **flushed** on [`visibilitychange`](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) and [`pagehide`](https://developer.mozilla.org/en-US/docs/Web/API/Window/pagehide_event), and also before you switch to another resume. So in the worst case, you only lose whatever you typed in the last half second.
+
+Reading also has a safety net. When a document comes back from [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API), it goes through a **forward-only migration ladder** first, and the raw document gets snapshotted to a `backups` store before any migration runs. If a document can't be migrated, it stays untouched on disk and shows up as unreadable. It's never overwritten.
+
+So that's the story of the state. [Zustand](https://zustand.docs.pmnd.rs/learn/getting-started/introduction) is the truth while the tab is open, [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) is the truth when it's closed, and they're never more than 500ms apart. There's no third place. No server cache, no cloud sync, nothing to leak.
+
+### Agentic Coding
+
+I didn't build Lanjut alone. I built it with [Claude Code](https://claude.com/claude-code). And to be clear, this is not "AI wrote my app".
+
+I learned quickly that an agent is only as good as the rules you write down. So most of my work moved one level up, from writing code to writing **constraints**. Lanjut's repo has an `AGENTS.md` that contains the two-layer rule, the migration rules (never blank a document that can't be parsed), and one line that I care about the most, _no resume content is sent to any server, confirm this on every PR touching data flow_. Claude reads that file on every session. Funny enough, when I asked for a feature that breaks the rule, it pushed back using my own rules.
+
+Before building anything big, I also asked the agent to **grill me** first. Not writing code, just questioning my plan. What happens if a migration fails halfway? What happens if two tabs edit the same resume? Why debounce and not write-through? Most of the design decisions in the previous two sections came from those conversations, before a single line of code exists.
+
+After that, Claude typed a lot, and I reviewed. It wrote the code, but every decision inside the code is mine.
+
+So no, agentic coding didn't replace my judgment. It forced me to write my judgment down. Every constraint in this post exists as a plain text file in the repository, and that's why the agent could move fast without breaking the promise.
+
+## Why It's Free
+
+Two reasons, one practical and one personal.
+
+**The practical one**: it costs me almost nothing to run. There's no server-side storage, no accounts, no database. Cloudflare serves static-ish pages and your browser does the rest. When your infrastructure bill is close to zero, a paywall is just greed.
+
+**The personal one**: the people who need this tool are looking for a job. Some of them are fresh graduates, some just got laid off. I'm not going to stand between them and their next opportunity with a checkout page.
+
+It's also open source, under [AGPL](https://en.wikipedia.org/wiki/GNU_Affero_General_Public_License). If you don't trust my claim that your data never leaves the browser, you don't have to. [Read the code](https://github.com/rimzzlabs/lanjut).
+
+## What's Next?
+
+Lanjut is not finished, and honestly a resume builder _never is_.
+
+The near-term list: more templates, section reordering, and keeping the export output tested against real ATS parsers, not just my own validation script. I also want to keep listening. If something breaks or a section type you need is missing, open an issue on [GitHub](https://github.com/rimzzlabs/lanjut/issues).
+
+But the core **promise will not change**. **Free**, **local**, **parseable**. If a feature request asks me to trade parseability for decoration, the answer stays no, no matter how nice it would look.
+
+That's Lanjut. You can try it right now at [lanjut.rimzzlabs.com](https://lanjut.rimzzlabs.com), and if this note made you curious about how it works, [see the source code](https://github.com/rimzzlabs/lanjut). I hope it helps you land somewhere good.

--- a/src/content/notes/id/introducing-lanjut.mdx
+++ b/src/content/notes/id/introducing-lanjut.mdx
@@ -1,0 +1,188 @@
+---
+title: "Memperkenalkan Lanjut. ATS-Friendly Resume Builder"
+description: "Resume ATS-Friendly sudah menjadi salah satu standar industri di masa sekarang. Tapi banyak orang kesulitan membuatnya, jadi saya merilis Lanjut. Sebuah resume builder yang ATS-Friendly."
+publishedAt: "06/07/2026"
+status: "draft"
+featured: true
+author: rimzzlabs
+keywords:
+  - ATS Resume Builder
+  - ATS Resume
+  - rimzzlabs ATS Resume Builder
+  - Free ATS Resume Builder
+  - Rizki Citra
+  - Local ATS Resume Builder
+---
+
+Resume ATS-Friendly sudah menjadi salah satu standar industri di kebanyakan perusahaan masa kini. Tapi banyak orang kesulitan membuatnya, apalagi di Indonesia.
+
+Di rekayasa perangkat lunak, kita selalu bergantung pada informasi, karena informasi adalah salah satu elemen dari software. Tapi bukan cuma itu, informasinya juga harus memberikan kejelasan.
+
+Itulah tugas resume, dia harus memberikan informasi yang jelas tentang kandidat, baik skill maupun latar belakangnya. Supaya perusahaan bisa mencocokkan budaya mereka dengan kandidat tersebut.
+
+## Sebelum ATS-Friendly
+
+Biar saya ingatkan lagi seperti apa melamar kerja di Indonesia, belum lama ini.
+
+Kamu pergi ke tempat fotokopi dan membeli _map cokelat_. Isinya: **surat lamaran tulis tangan**, **CV** kamu, fotokopi **ijazah** yang sudah dilegalisir, **SKCK** dari kepolisian, **kartu kuning** dari dinas setempat, dan **foto 3x4 dengan latar merah**. Lalu map itu kamu bawa ke job fair, atau kamu serahkan langsung ke satpam di gerbang depan perusahaan.
+
+Beberapa berkas itu bahkan ada masa berlakunya. Kalau dalam beberapa bulan kamu belum diterima kerja, kamu antre lagi di kantor polisi.
+
+Lalu semuanya pindah ke online. Email, [Jobstreet](https://jobstreet.com), [LinkedIn](https://linkedin.com). Kedengarannya seperti kemajuan, dan memang iya. Tapi sekarang satu lowongan bisa menerima ratusan bahkan ribuan pelamar. Tidak ada manusia yang membaca semua itu. Jadi perusahaan membiarkan software yang membacanya lebih dulu, dan software itu bernama ATS, Applicant Tracking System.
+
+Birokrasinya tidak pernah benar-benar hilang. Dia cuma berubah bentuk. Dulu penjaga gerbangnya adalah berkas. Sekarang penjaga gerbangnya adalah parser.
+
+## Ghosting
+
+Kamu kirim resume. Satu minggu, tidak ada kabar. Satu bulan, tidak ada kabar. Bahkan email penolakan pun tidak ada.
+
+_Kita_ menyebutnya _ghosting_, tapi besar kemungkinan tidak ada orang yang benar-benar memutuskan untuk mengabaikanmu. Resume kamu memang tidak pernah sampai ke manusia. ATS mencoba mengekstrak nama, pengalaman, dan skill kamu ke dalam database-nya, lalu gagal di tengah jalan.
+
+Saya sering melihat ini terjadi pada template-template populer. Dua kolom, ikon untuk nomor telepon, bar chart untuk skill. Terlihat bagus di mata kita. Tapi parser membaca teks secara berurutan, jadi dua kolom itu tercampur, dan pengalaman kerja kamu menempel dengan hobi kamu. Sistem menandai kamu sebagai tidak lengkap, dan kamu tidak pernah tahu kenapa.
+
+Itu bagian kejamnya. Kamu sudah berusaha, kamu punya skill-nya, tapi kamu tersaring keluar karena masalah format yang tidak bisa kamu lihat.
+
+## Budaya di Perusahaan
+
+Kenapa ada **"budaya"** di sebuah perusahaan? Dan kenapa setiap perusahaan melihatnya berbeda-beda?
+
+Perusahaan itu sebenarnya cuma sekumpulan orang yang bekerja bersama selama bertahun-tahun. Seiring waktu mereka membangun kebiasaan: cara mengambil keputusan, cara menangani kesalahan, seberapa cepat mereka bergerak. Akumulasi itulah yang disebut budaya. Startup beranggota tiga orang dan bank berumur lima puluh tahun bisa merekrut untuk posisi yang sama persis, tapi mencari orang yang sangat berbeda.
+
+Jadi ketika perusahaan membaca resume kamu, mereka tidak cuma mengecek apakah kamu bisa mengerjakan pekerjaannya. Mereka juga menebak apakah kamu bisa bekerja dengan cara mereka bekerja. Itulah kenapa resume yang sama bisa ditolak di satu tempat dan dirayakan di tempat lain.
+
+### Haruskah _Saya_ Menyesuaikan Diri?
+
+Sejujurnya? Tidak selalu.
+
+Kecocokan budaya itu bekerja dua arah. Kalau perusahaan menolak kamu karena cara mereka membaca latar belakangmu, mungkin kamu juga baru saja terhindar dari tempat yang akan membuatmu tersiksa. Penolakan tidak selalu berarti penilaian atas skill kamu. Kadang itu cuma soal tidak cocok.
+
+Tapi ini yang saya percaya: pencocokan itu harus gagal karena alasan yang benar. Gagal karena kamu dan perusahaannya memang tidak cocok, bukan karena parser mengacak resume kamu. Kamu berhak ditolak oleh manusia, bukan oleh bug.
+
+## Kenapa Saya Membangun Lanjut
+
+Jadi saya coba lihat-lihat tools yang sudah ada, dan jujur saja, saya kurang suka dengan apa yang saya temukan.
+
+Resume builder yang populer biasanya begini. Template yang aman untuk ATS dikunci di balik _subscription_, atau kamu dikasih template gratis yang kelihatan cantik tapi hasil parsing-nya berantakan. Dua-duanya bikin kamu rugi. Dan hampir semuanya menyimpan resume kamu di _server_ mereka. Artinya riwayat karier, nomor telepon, sampai alamat rumah kamu ada di _database_ orang lain.
+
+Coba pikir, siapa yang paling butuh resume builder? Orang yang lagi cari kerja. Masa iya mereka harus bayar bulanan cuma supaya bisa melamar kerja? Buat saya itu rasanya salah.
+
+Jadi saya buat Lanjut. Namanya saya ambil dari kata **"lanjut"** yang artinya meneruskan, dan kebetulan, itu juga arti harfiah dari kata **"resume"**.
+
+### Filosofi
+
+Lanjut berdiri di atas tiga ide.
+
+Pertama, struktur dikunci, presentasi bebas. Kamu tidak bisa menambahkan tabel, kolom, atau text box melayang, karena semua itu merusak parsing. Tapi tipografi, spacing, warna, itu semua milikmu. Batasan ini bukan kekurangan, justru itu intinya. Setiap keputusan desain yang bisa merusak parseability memang tidak tersedia untuk dipilih.
+
+Kedua, datamu adalah milikmu. Semuanya hidup di penyimpanan lokal browser kamu. Tidak ada akun, tidak ada sign up, tidak ada server yang pernah melihat isi resume kamu. Tutup tab-nya, kembali besok, masih ada. Di perangkatmu, tidak di tempat lain.
+
+Ketiga, kejelasan di atas dekorasi. Resume adalah informasi, dan informasi harus memberikan kejelasan. Selain itu, semuanya bisa dinegosiasikan.
+
+## Bagaimana Saya Membangun Lanjut
+
+Saya membangunnya dengan urutan yang ketat, dan urutannya penting.
+
+Skema data dan penyimpanan dulu. Lalu layer state di atasnya. Lalu **pengalaman menyunting**. Setelah itu, dan hanya setelah itu, tema visualnya. Export datang paling akhir, bersama **dengan validasi**.
+
+Kenapa urutannya begitu? Karena seluruh janji **Lanjut** adalah **presentasi tidak boleh merusak struktur**. Kalau saya mulai dari template yang cantik, strukturnya pasti bengkok demi melayani visual. Dengan membangun layer data lebih dulu, **template tidak punya pilihan selain menghormatinya**.
+
+### Arsitektur Lanjut
+
+Stack-nya adalah [Next.js](https://nextjs.org) dengan **App Router**, di-deploy ke [Cloudflare](https://cloudflare.com) melalui [open-next](https://opennext.js.org). Tapi Cloudflare hanya menyajikan aplikasinya; **tidak ada data resume yang pernah menyentuh server function atau API route**.
+
+State hidup di [zustand](https://zustand.docs.pmnd.rs/learn/getting-started/introduction), dan setiap perubahan disinkronkan ke [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) dengan _debounce_. Itu saja cerita persistensinya. Tidak ada **tagihan database**, **tidak ada layanan backup**, dan **tidak ada celah kebocoran**.
+
+Field rich text memakai [TipTap](https://tiptap.dev), tapi dengan set extension yang **sengaja** dibuat kecil: **bold**, **italic**, **bullet list**, **ordered list**, **link**. Itu saja. Kalau sebuah opsi format bisa membingungkan parser, opsi itu tidak ada di editornya.
+
+Ada **enam template**, dan semuanya me-_render_ **urutan blok linear** yang sama persis. Ganti template hanya mengubah _font_ dan _spacing_, tidak pernah mengubah urutan baca. Bentuk dokumennya juga punya versi. Kalau bentuknya berubah, dokumen lama akan **dinaikkan versinya secara bertahap, satu arah, tanpa pernah turun kembali**, dan setiap dokumen di-_snapshot_ dulu sebelum migrasi. Kalau migrasi tidak bisa membaca datamu, dia menyimpan yang asli dan tidak melakukan apa-apa. Resume kamu tidak akan pernah dikosongkan oleh update.
+
+### Strukturnya
+
+Seperti ini bentuk codebase-nya. Saya pangkas ke bagian yang penting saja:
+
+```text
+src/
+├── app/[locale]/            # routes; editor-nya ada di /platform
+├── components/
+│   ├── editor/              # pengalaman menyunting
+│   │   ├── rich-text/       # TipTap, dengan set extension kecil
+│   │   ├── templates/       # enam template
+│   │   ├── docx/ pdf/       # renderer export
+│   │   └── editor-sections/ # satu folder per bagian resume
+│   ├── platform/            # library: daftar resume kamu.
+│   └── ui/                  # primitif shadcn
+├── hooks/                   # use-resume-document, dll.
+├── i18n/                    # Inggris dan Indonesia
+└── lib/
+    ├── resume/              # dokumennya: types, factory, migrations
+    ├── db/                  # IndexedDB: schema, repository
+    ├── store/               # zustand store + persistensi debounce
+    └── forms/               # skema validasi
+```
+
+Aturan paling penting di sini adalah **arah _dependency_**. `lib/resume` mendefinisikan resume itu _apa_, dia tidak tahu apa-apa soal penyimpanan atau [React](https://react.dev). `lib/db` tahu cara menyimpan dokumen itu, tapi tidak tahu apa-apa soal _User Interface_. `lib/store` berada di atas keduanya, dan dialah satu-satunya layer yang boleh diajak bicara oleh _components_. Template dan _renderer export_ hidup di `components`, di ujung paling akhir rantai. Mereka bisa membaca dokumen, tapi tidak akan pernah bisa mengubah definisi dokumen itu sendiri.
+
+Dan kalau kamu baca _tree_-nya dari bawah ke atas, itu urutan _build_ yang sama seperti yang saya sebutkan sebelumnya. Dokumen, penyimpanan, _state_, _editor_, template, dan _export_ di paling akhir. Jadi janji **presentasi tidak boleh merusak struktur** bukan sekadar kata-kata di tulisan ini. Itu benar-benar struktur foldernya.
+
+### Bagaimana State-nya Hidup
+
+Resume kamu hidup di dua tempat. Di memori dengan [zustand](https://zustand.docs.pmnd.rs/learn/getting-started/introduction) selama tab terbuka, dan di [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) saat tidak. Seluruh tugas _layer_ persistensi adalah menjaga keduanya tetap sinkron.
+
+Setiap perubahan yang kamu buat akan melewati satu fungsi di store. Fungsi ini meng-_clone_ dokumen yang sedang terbuka, menerapkan perubahanmu, dan langsung memperbarui _User Interface_. Tapi dia tidak langsung menyimpan ke IndexedDB, dia cuma _menjadwalkan_ penyimpanannya:
+
+```ts
+updateOpen(recipe) {
+  const draft = structuredClone(get().open)
+  recipe(draft)
+  draft.updatedAt = new Date().toISOString()
+  set({ open: draft })
+  scheduleOpenResumePersist() // satu-satunya jembatan ke disk
+}
+```
+
+Jembatannya cuma satu penyimpanan yang di-_[debounce](https://developer.mozilla.org/en-US/docs/Glossary/Debounce)_. Kalau kamu mengetik cepat, semua ketikan itu menyatu jadi **satu** `put` IndexedDB, sekitar 500ms setelah kamu berhenti mengetik:
+
+```ts
+const controlled = F.makeControlledDebounce(() => void persistOpenNow(), {
+  delay: 500,
+  leading: false,
+});
+```
+
+Tapi _[debounce](https://developer.mozilla.org/en-US/docs/Glossary/Debounce)_ saja berbahaya. Bagaimana kalau kamu menutup tab 400ms setelah ketikan terakhir? Karena itu penyimpanan yang tertunda akan di-**_flush_** saat _[`visibilitychange`](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API)_ dan _[`pagehide`](https://developer.mozilla.org/en-US/docs/Web/API/Window/pagehide_event)_, dan juga sebelum kamu pindah ke resume lain. Jadi di kasus terburuk, kamu hanya kehilangan apa yang kamu ketik dalam setengah detik terakhir.
+
+Membaca juga punya sistem pengaman. Saat dokumen kembali dari [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API), dia **dinaikkan dulu ke versi bentuk yang terbaru secara bertahap**, dan dokumen mentahnya di-_snapshot_ ke store _`backups`_ sebelum migrasi apa pun berjalan. Kalau dokumen tidak bisa dimigrasikan, dia tetap utuh di disk dan muncul sebagai tidak terbaca. Tidak pernah ditimpa.
+
+Jadi begitulah cerita _state_-nya. State dipegang oleh [Zustand](https://zustand.docs.pmnd.rs/learn/getting-started/introduction) selama tab terbuka, lalu dipegang oleh [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) saat tab tertutup, dan jarak keduanya tidak pernah lebih dari 500ms. Tidak ada tempat ketiga. Tidak ada _cache_ di _server_, tidak ada sinkronisasi ke _cloud_, tidak ada yang bocor.
+
+### _Agentic Coding_
+
+Saya tidak membangun Lanjut sendirian. Saya membangunnya bersama [Claude Code](https://claude.com/claude-code). Dan biar jelas, ini bukan "AI yang menulis aplikasi saya".
+
+Saya cepat belajar bahwa _agent_ hanya sebagus aturan yang kamu tuliskan. Jadi sebagian besar pekerjaan saya naik satu level, dari menulis kode menjadi menulis **batasan**. _Repository_ Lanjut punya `AGENTS.md` yang berisi aturan dua layer, aturan migrasi (jangan pernah mengosongkan dokumen yang tidak bisa dibaca), dan satu baris yang paling saya pedulikan, _tidak ada isi resume yang dikirim ke server mana pun, konfirmasi ini di setiap PR yang menyentuh alur data_. Claude membaca file itu di setiap sesi. Lucunya, saat saya minta fitur yang melanggar aturan itu, dia menolak dengan memakai aturan saya sendiri.
+
+Sebelum membangun sesuatu yang besar, saya juga meminta agent untuk **menginterogasi saya** dulu. Bukan menulis kode, cuma mempertanyakan rencana saya. Apa yang terjadi kalau migrasi gagal di tengah jalan? Apa yang terjadi kalau dua tab menyunting resume yang sama? Kenapa debounce dan bukan write-through? Sebagian besar keputusan desain di dua bagian sebelumnya lahir dari percakapan-percakapan itu, sebelum satu baris kode pun ada.
+
+Setelah itu, Claude mengetik banyak sekali, dan saya me-review. Dia yang menulis kodenya, tapi setiap keputusan di dalam kode itu milik saya.
+
+Jadi tidak, _agentic coding_ tidak menggantikan penilaian saya. Dia memaksa saya menuliskan penilaian saya. Setiap batasan di tulisan ini ada sebagai file teks biasa di repository, dan karena itulah agent bisa bergerak cepat tanpa melanggar janjinya.
+
+## Kenapa Gratis
+
+Dua alasan, satu praktis dan satu personal.
+
+**Yang praktis**: biaya menjalankannya hampir nol. Tidak ada penyimpanan di sisi server, tidak ada akun, tidak ada database. Cloudflare menyajikan halaman yang nyaris statis dan sisanya dikerjakan browser kamu. Kalau tagihan infrastrukturmu mendekati nol, paywall itu cuma keserakahan.
+
+**Yang personal**: orang-orang yang butuh tool ini sedang mencari kerja. Sebagian fresh graduate, sebagian baru saja kena layoff. Saya tidak akan berdiri di antara mereka dan kesempatan berikutnya dengan halaman checkout.
+
+Lanjut juga _open source_, di bawah lisensi [AGPL](https://en.wikipedia.org/wiki/GNU_Affero_General_Public_License). Kalau kamu tidak percaya klaim saya bahwa datamu tidak pernah meninggalkan browser, kamu tidak harus percaya. [Baca kodenya](https://github.com/rimzzlabs/lanjut).
+
+## Selanjutnya Apa?
+
+Lanjut belum selesai, dan jujur saja resume _builder_ itu _tidak akan pernah selesai_.
+
+Daftar jangka pendeknya: lebih banyak template, pengurutan ulang section, dan menjaga hasil export tetap diuji terhadap parser ATS sungguhan, bukan cuma script validasi saya sendiri. Saya juga ingin terus mendengarkan. Kalau ada yang rusak atau tipe section yang kamu butuhkan belum ada, buka issue di [GitHub](https://github.com/rimzzlabs/lanjut/issues).
+
+Tapi **janji intinya tidak akan berubah**. **Gratis**, **lokal**, **bisa di-parse**. Kalau sebuah permintaan fitur meminta saya menukar parseability demi dekorasi, jawabannya tetap tidak, sebagus apa pun tampilannya.
+
+Itulah Lanjut. Kamu bisa mencobanya sekarang di [lanjut.rimzzlabs.com](https://lanjut.rimzzlabs.com), dan kalau tulisan ini membuatmu penasaran bagaimana cara kerjanya, [lihat kodenya](https://github.com/rimzzlabs/lanjut). Semoga Lanjut membantumu mendapatkan pekerjaan di tempat yang baik.


### PR DESCRIPTION
## Summary
- New note component [note-link.astro](src/components/notes/note-link.astro) mapped over MDX anchors: `https` links open in a new tab with `rel="noopener"`, an inline ArrowUpRight icon, and a `utm_source` param; internal and hash anchors pass through untouched
- New draft note **Introducing Lanjut** in English and Indonesian (`status: draft`): the ATS backstory, why/how Lanjut was built, architecture deep-dives (structure, zustand + IndexedDB state, agentic coding), and why it stays free

## Verification
- `pnpm build` passes; built HTML checked: external anchors get `target="_blank" rel="noopener"` + icon, internal and heading autolink anchors unchanged
- All 18 outbound URLs in the post return HTTP 200
- Both language versions cross-checked section by section for typos and consistency