### PR TITLE
fix(notes): WCAG AA code themes and idle hydration on note pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -42,7 +42,7 @@ export default defineConfig({
 	markdown: {
 		syntaxHighlight: "shiki",
 		shikiConfig: {
-			themes: { light: "github-light", dark: "vitesse-dark" },
+			themes: { light: "github-light-default", dark: "github-dark-default" },
 			wrap: true,
 		},
 		rehypePlugins: [rehypeSlug, rehypeAutolinkHeadings],

--- a/src/components/notes/note-article.astro
+++ b/src/components/notes/note-article.astro
@@ -71,7 +71,7 @@ const authorName = author?.data.fullName ?? note.data.author.id;
 
     <DotPattern
       glow
-      client:load
+      client:idle
       className="mask-[radial-gradient(300px_circle_at_center,var(--background),transparent)]"
     />
   </div>
@@ -79,7 +79,7 @@ const authorName = author?.data.fullName ?? note.data.author.id;
   <section
     class="container-fluid py-10 sm:flex sm:flex-row-reverse sm:justify-between"
   >
-    <NotesToc client:load headings={headings} label={t.onThisPage} />
+    <NotesToc client:idle headings={headings} label={t.onThisPage} />
     <article class="prose prose-stone flex-1 dark:prose-invert">
       <Content components={{ a: NoteLink }} />
     </article>


### PR DESCRIPTION
## Summary
- Swap Shiki themes `github-light`/`vitesse-dark` → `github-light-default`/`github-dark-default`. Measured every token color against the theme background across 17 candidate themes: the old pair fails WCAG AA (github-light orange at 3.49:1, blue at 4.45:1; vitesse-dark punctuation at 3.26:1), the new pair passes on all tokens in both light (min 4.55:1) and dark (min 6.15:1) mode
- Hydrate the decorative `DotPattern` and `NotesToc` on `client:idle` instead of `client:load` on note pages

## Verification
- Lighthouse (production build, local preview): accessibility **96 → 100** on `/notes/jotai-recipes`, color-contrast audit passing, performance steady at 95, CLS ~0
- Dark-mode token contrast verified computationally (Lighthouse only tests the rendered light theme)