### PR TITLE
fix(perf): CSS-driven dot pattern and TOC heading order

### DIFF
--- a/src/components/notes/notes-toc.tsx
+++ b/src/components/notes/notes-toc.tsx
@@ -41,7 +41,7 @@ export function NotesToc({ headings, label }: { headings: Array<MarkdownHeading>
 	return (
 		<aside className="max-w-max pl-14 max-sm:hidden">
 			<div className="sticky top-8 right-0">
-				<h3 className="pb-4 text-lg font-semibold">{label}</h3>
+				<h2 className="pb-4 text-lg font-semibold">{label}</h2>
 				<nav className="relative overflow-y-hidden">
 					<ul className="list-outside border-l-2 text-left">
 						{nested.map((heading) => (

--- a/src/components/ui/dot-pattern.tsx
+++ b/src/components/ui/dot-pattern.tsx
@@ -1,4 +1,3 @@
-import { motion } from "motion/react";
 import type React from "react";
 import { useEffect, useId, useRef, useState } from "react";
 import { useMotionEnabled } from "@/hooks/use-motion";
@@ -13,6 +12,13 @@ interface DotPatternProps extends React.SVGProps<SVGSVGElement> {
 	className?: string;
 	glow?: boolean;
 }
+
+/**
+ * Dots that pulse in glow mode. A fixed count (not one per grid cell) so the
+ * animation cost stays constant on any viewport; the pulse itself is pure CSS,
+ * keeping the main thread idle for Lighthouse's quiescence check.
+ */
+const TWINKLE_COUNT = 60;
 
 /** Animated/static SVG dot-pattern background; the glow pulse respects the motion preference. */
 export function DotPattern({
@@ -46,22 +52,28 @@ export function DotPattern({
 
 	const cols = Math.ceil(dimensions.width / width);
 	const rows = Math.ceil(dimensions.height / height);
-	const dots = Array.from({ length: cols * rows }, (_, i) => {
-		const col = i % cols;
-		const row = Math.floor(i / cols);
-		return {
-			x: col * width + cx,
-			y: row * height + cy,
-			delay: Math.random() * 5,
-			duration: Math.random() * 3 + 2,
-		};
-	});
+	const cells = cols * rows;
+	const twinkleCells = new Set<number>();
+	if (animateGlow && cells > 0) {
+		while (twinkleCells.size < Math.min(TWINKLE_COUNT, cells)) {
+			twinkleCells.add(Math.floor(Math.random() * cells));
+		}
+	}
+	const twinkles = [...twinkleCells].map((cell) => ({
+		x: (cell % cols) * width + cx,
+		y: Math.floor(cell / cols) * height + cy,
+		delay: Math.random() * 5,
+		duration: Math.random() * 3 + 2,
+	}));
 
 	return (
 		<svg
 			ref={containerRef}
 			aria-hidden="true"
-			className={cn("pointer-events-none absolute inset-0 h-full w-full", className)}
+			className={cn(
+				"pointer-events-none absolute inset-0 h-full w-full text-neutral-400/80",
+				className,
+			)}
 			{...props}
 		>
 			<defs>
@@ -69,28 +81,20 @@ export function DotPattern({
 					<stop offset="0%" stopColor="currentColor" stopOpacity="1" />
 					<stop offset="100%" stopColor="currentColor" stopOpacity="0" />
 				</radialGradient>
+				<pattern id={`${id}-pattern`} width={width} height={height} patternUnits="userSpaceOnUse">
+					<circle cx={cx} cy={cy} r={cr} fill={glow ? `url(#${id}-gradient)` : "currentColor"} />
+				</pattern>
 			</defs>
-			{dots.map((dot) => (
-				<motion.circle
+			<rect width="100%" height="100%" fill={`url(#${id}-pattern)`} />
+			{twinkles.map((dot) => (
+				<circle
 					key={`${dot.x}-${dot.y}`}
 					cx={dot.x}
 					cy={dot.y}
 					r={cr}
-					fill={glow ? `url(#${id}-gradient)` : "currentColor"}
-					className="text-neutral-400/80"
-					initial={glow ? { opacity: 0.4, scale: 1 } : {}}
-					animate={animateGlow ? { opacity: [0.4, 1, 0.4], scale: [1, 1.5, 1] } : {}}
-					transition={
-						animateGlow
-							? {
-									duration: dot.duration,
-									repeat: Number.POSITIVE_INFINITY,
-									repeatType: "reverse",
-									delay: dot.delay,
-									ease: "easeInOut",
-								}
-							: {}
-					}
+					fill={`url(#${id}-gradient)`}
+					className="dot-twinkle"
+					style={{ animationDelay: `${dot.delay}s`, animationDuration: `${dot.duration}s` }}
 				/>
 			))}
 		</svg>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -149,6 +149,25 @@
 	@apply mx-auto w-11/12 max-w-5xl;
 }
 
+/* Dot-pattern glow pulse — CSS-driven so the animation never occupies the JS
+   main thread (Lighthouse quiescence would time out on JS-driven loops). */
+@keyframes dot-twinkle {
+	0%,
+	100% {
+		opacity: 0.4;
+		transform: scale(1);
+	}
+	50% {
+		opacity: 1;
+		transform: scale(1.5);
+	}
+}
+.dot-twinkle {
+	transform-box: fill-box;
+	transform-origin: center;
+	animation: dot-twinkle 3s ease-in-out infinite;
+}
+
 /* Notes (markdown) — autolink heading anchors from rehype-autolink-headings */
 .prose :is(h2, h3, h4, h5, h6) {
 	@apply relative max-w-max scroll-mt-24;


### PR DESCRIPTION
## Summary
Fixes the PSI desktop error *"The page loaded too slowly to finish within the time limit"*.

- **Root cause**: `DotPattern` rendered one `motion.circle` per 16px grid cell — ~5,000 elements on a desktop viewport, each running an infinite JS-driven animation. The main thread never went quiet, so Lighthouse's quiescence detection timed out (desktop-only because mobile viewports produce ~4× fewer dots)
- **Fix**: static grid is now a single SVG `<pattern>` + `<rect>` (2 DOM nodes); the glow is a fixed set of 60 twinkle dots animated with pure CSS keyframes. `motion/react` dropped from the component. Reduced-motion preference still disables the twinkle
- **Also**: TOC label `h3` → `h2` — it directly follows the page `h1` in DOM order and failed the heading-order audit on desktop (TOC is hidden on mobile)

## Verification
- Desktop Lighthouse on `/notes/jotai-recipes` (production build): **no run warnings**, 100 perf / 100 a11y / 100 BP / 100 SEO, TBT 0ms; mobile re-checked, no regressions
- Visual compared against the live site screenshot-by-screenshot: base field matches the old pulse's peak brightness; twinkle animation preserved