### PR TITLE
fix(notes): stop mobile horizontal scroll from heading anchor marker

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -172,11 +172,14 @@
 .prose :is(h2, h3, h4, h5, h6) {
 	@apply relative max-w-max scroll-mt-24;
 }
-.prose span.icon-link {
-	@apply before:absolute before:-right-6 before:top-1 before:px-1 before:text-[0.9em] before:text-orange-600 before:opacity-0 before:transition before:content-['#'];
-}
-.prose :is(h2, h3, h4, h5, h6):hover span.icon-link::before {
-	@apply opacity-100;
+
+@media (hover: hover) {
+	.prose span.icon-link {
+		@apply before:absolute before:-right-6 before:top-1 before:px-1 before:text-[0.9em] before:text-orange-600 before:opacity-0 before:transition before:content-['#'];
+	}
+	.prose :is(h2, h3, h4, h5, h6):hover span.icon-link::before {
+		@apply opacity-100;
+	}
 }
 
 /* Notes (markdown) — Shiki dual theme: use the dark palette under .dark */


### PR DESCRIPTION
## Problem

Note articles had a horizontal scroll on mobile — the body exceeded the viewport width. Reported on `id/introducing-lanjut`, but it affects **every** note article (both locales).

## Root cause

Not paragraph wrapping. The culprit is the heading autolink `#` marker (`.prose span.icon-link::before`), positioned `-right-6` — **24px outside** each heading's right edge. Because headings use `max-w-max`, a long heading fills the column on mobile and pushes that marker past the container, spilling ~8px beyond the viewport.

Measured with headless Chrome at 375px: `h2` right edge = 359px, `359 + 24 = 383px` = page `scrollWidth` (viewport 375px). The marker is `opacity-0` unless hovered, so on touch devices it was invisible dead weight that only produced the scrollbar.

## Fix

Scope the marker and its `:hover` rule to `@media (hover: hover)`. Touch devices no longer render the offset pseudo-element (they could never reveal it anyway); desktop behavior is unchanged.

## Verification

Headless Chrome, real layout, `scrollWidth` vs `clientWidth`:

| Viewport | Mode | Result |
|---|---|---|
| 320px | hover:none | 320 = 320 ✅ |
| 375px | hover:none | 375 = 375 ✅ (was 383) |
| 414px | hover:none | 414 = 414 ✅ |
| 1280px | hover:hover | 1280 = 1280 ✅ marker still positioned |

`pnpm check` passes (0 errors).