### PR TITLE
feat(i18n): localize Lanjut resume callout

### DIFF
--- a/src/components/home/experience.astro
+++ b/src/components/home/experience.astro
@@ -83,16 +83,28 @@ const experiences = companies.map(({ key, company, url }) => ({
     }
   </ol>
 
-  <p class="text-muted-foreground pt-4">
-    {t.resumeLead}{" "}
-    <a
-      href="/attachments/rizki_citra_resume.pdf"
-      target="_blank"
-      rel="noopener"
-      class="underline hover:text-foreground transition-colors"
-    >
-      {t.resumeLink}<span class="span sr-only">{t.resumeLinkSr}</span>
-      <ArrowUpRight className="inline size-3 align-text-top" />
-    </a>
-  </p>
+  <blockquote
+    class="border-l-4 border-l-accent-foreground pl-2 text-sm text-muted-foreground max-w-xl"
+  >
+    <p class="text-muted-foreground">
+      {t.resumeLead}{" "}
+      <a
+        href="/attachments/rizki_citra_resume.pdf"
+        target="_blank"
+        rel="noopener"
+        class="underline hover:text-foreground transition-colors"
+      >
+        {t.resumeLink}<span class="sr-only">{t.resumeLinkSr}</span>
+        <ArrowUpRight className="inline size-3 align-text-top" />
+      </a>{" "}{t.resumeToolLead}{" "}
+      <a
+        rel="noopener"
+        target="_blank"
+        href="https://lanjut.rimzzlabs.com"
+        class="underline hover:text-foreground transition-colors"
+      >
+        Lanjut <ArrowUpRight className="inline size-3.5 align-text-top" />
+      </a>{t.resumeToolTail}
+    </p>
+  </blockquote>
 </Section>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -94,17 +94,19 @@ export const en = {
 		headingSr: "My ",
 		intro:
 			"A quick ledger of where I've worked and what I shipped. The longer story lives further down.",
-		resumeLead: "You can see a complete profile on",
-		resumeLink: "my Résumé",
-		resumeLinkSr: "See it here",
+		resumeLead: "You can see a complete profile in my",
+		resumeLink: "résumé",
+		resumeLinkSr: ", see it here",
+		resumeToolLead: "I created my resume with",
+		resumeToolTail: ", it's 100% free and open source. Try it out!",
 		items: {
 			kolosal: {
-				title: "Software Engineer",
+				title: "Frontend Engineer",
 				period: "Nov 2025 - Present",
 				summary: "Building AI products with a small, sharp team.",
 			},
 			bitwyre: {
-				title: "Software Engineer (Frontend)",
+				title: "Frontend Engineer",
 				period: "Feb 2024 - Nov 2025",
 				summary: "Shipped the frontend for a global crypto, web3 and trading platform.",
 			},

--- a/src/i18n/id.ts
+++ b/src/i18n/id.ts
@@ -102,15 +102,17 @@ export const id: Dictionary = {
 			"Catatan singkat tentang tempat saya bekerja dan apa yang saya kerjakan. Cerita lengkapnya ada di bawah.",
 		resumeLead: "Anda bisa melihat profil lengkapnya di",
 		resumeLink: "Résumé saya",
-		resumeLinkSr: "Lihat di sini",
+		resumeLinkSr: ", lihat di sini",
+		resumeToolLead: "Saya membuat résumé ini dengan",
+		resumeToolTail: ", 100% gratis dan open source.",
 		items: {
 			kolosal: {
-				title: "Software Engineer",
+				title: "Frontend Engineer",
 				period: "Nov 2025 - Sekarang",
-				summary: "Membangun produk AI bersama tim kecil yang tajam.",
+				summary: "Membangun produk AI bersama tim kecil tapi keren.",
 			},
 			bitwyre: {
-				title: "Software Engineer (Frontend)",
+				title: "Frontend Engineer",
 				period: "Feb 2024 - Nov 2025",
 				summary: "Mengembangkan frontend untuk platform kripto, web3, dan trading global.",
 			},


### PR DESCRIPTION
Move the resume callout's Lanjut copy into the en/id dictionaries via `resumeToolLead` + `resumeToolTail`.