### PR TITLE
refactor(contact): use Field and InputGroup primitives

### DIFF
--- a/src/components/shared/contact/contact-form.tsx
+++ b/src/components/shared/contact/contact-form.tsx
@@ -1,28 +1,20 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { CheckCircle2, Send, XIcon } from "lucide-react";
+import { AtSign, CheckCircle2, Send, Tag, User2, XIcon } from "lucide-react";
 import { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
 import { useContactForm } from "@/hooks/use-contact-form";
 import type { Lang } from "@/i18n/config";
 import { getDictionary } from "@/i18n/dictionary";
 import type { Dictionary } from "@/i18n/en";
-import { cn } from "@/lib/utils";
 import { RichTextEditor } from "./rich-text-editor";
 import { Turnstile } from "./turnstile";
 
 type ContactCopy = Dictionary["contact"];
 type FormValues = z.infer<ReturnType<typeof buildSchema>>;
-
-const fieldClass = cn(
-	"h-8 w-full rounded-lg border border-input bg-background px-3 text-sm shadow-xs outline-none",
-	"transition-[color,box-shadow] placeholder:text-muted-foreground/70",
-	"focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50",
-	"aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20",
-);
-const labelClass = "text-sm font-medium";
-const errorClass = "text-xs text-destructive";
 
 function buildSchema(t: ContactCopy) {
 	return z.object({
@@ -88,54 +80,60 @@ export function ContactForm({
 	return (
 		<form onSubmit={onSubmit} noValidate className="grid gap-4">
 			<div className="grid gap-4 sm:grid-cols-2">
-				<div className="grid gap-1.5">
-					<label htmlFor="contact-name" className={labelClass}>
-						{t.nameLabel}
-					</label>
-					<input
-						id="contact-name"
-						placeholder={t.namePlaceholder}
-						autoComplete="name"
-						aria-invalid={errors.name ? true : undefined}
-						className={fieldClass}
-						{...register("name")}
-					/>
-					{errors.name && <p className={errorClass}>{errors.name.message}</p>}
-				</div>
+				<Field data-invalid={errors.name ? true : undefined}>
+					<FieldLabel htmlFor="contact-name">{t.nameLabel}</FieldLabel>
+					<InputGroup>
+						<InputGroupAddon>
+							<User2 />
+						</InputGroupAddon>
+						<InputGroupInput
+							id="contact-name"
+							placeholder={t.namePlaceholder}
+							autoComplete="name"
+							aria-invalid={errors.name ? true : undefined}
+							{...register("name")}
+						/>
+					</InputGroup>
+					<FieldError errors={[errors.name]} />
+				</Field>
 
-				<div className="grid gap-1.5">
-					<label htmlFor="contact-email" className={labelClass}>
-						{t.emailLabel}
-					</label>
-					<input
-						id="contact-email"
-						type="email"
-						placeholder={t.emailPlaceholder}
-						autoComplete="email"
-						aria-invalid={errors.email ? true : undefined}
-						className={fieldClass}
-						{...register("email")}
-					/>
-					{errors.email && <p className={errorClass}>{errors.email.message}</p>}
-				</div>
+				<Field data-invalid={errors.email ? true : undefined}>
+					<FieldLabel htmlFor="contact-email">{t.emailLabel}</FieldLabel>
+					<InputGroup>
+						<InputGroupAddon>
+							<AtSign />
+						</InputGroupAddon>
+						<InputGroupInput
+							id="contact-email"
+							type="email"
+							placeholder={t.emailPlaceholder}
+							autoComplete="email"
+							aria-invalid={errors.email ? true : undefined}
+							{...register("email")}
+						/>
+					</InputGroup>
+					<FieldError errors={[errors.email]} />
+				</Field>
 			</div>
 
-			<div className="grid gap-1.5">
-				<label htmlFor="contact-subject" className={labelClass}>
-					{t.subjectLabel}
-				</label>
-				<input
-					id="contact-subject"
-					placeholder={t.subjectPlaceholder}
-					aria-invalid={errors.subject ? true : undefined}
-					className={fieldClass}
-					{...register("subject")}
-				/>
-				{errors.subject && <p className={errorClass}>{errors.subject.message}</p>}
-			</div>
+			<Field data-invalid={errors.subject ? true : undefined}>
+				<FieldLabel htmlFor="contact-subject">{t.subjectLabel}</FieldLabel>
+				<InputGroup>
+					<InputGroupAddon>
+						<Tag />
+					</InputGroupAddon>
+					<InputGroupInput
+						id="contact-subject"
+						placeholder={t.subjectPlaceholder}
+						aria-invalid={errors.subject ? true : undefined}
+						{...register("subject")}
+					/>
+				</InputGroup>
+				<FieldError errors={[errors.subject]} />
+			</Field>
 
-			<div className="grid gap-1.5">
-				<span className={labelClass}>{t.messageLabel}</span>
+			<Field data-invalid={errors.bodyText ? true : undefined}>
+				<FieldLabel>{t.messageLabel}</FieldLabel>
 				<RichTextEditor
 					ariaLabel={t.messageLabel}
 					placeholder={t.messagePlaceholder}
@@ -146,16 +144,16 @@ export function ContactForm({
 						setValue("bodyText", text, { shouldValidate: Boolean(errors.bodyText) });
 					}}
 				/>
-				{errors.bodyText && <p className={errorClass}>{errors.bodyText.message}</p>}
-			</div>
+				<FieldError errors={[errors.bodyText]} />
+			</Field>
 
-			<div className="grid gap-1.5">
+			<Field>
 				<Turnstile
 					siteKey={siteKey}
 					onToken={(token) => setValue("token", token, { shouldValidate: Boolean(errors.token) })}
 				/>
-				{status === "error" && <p className={errorClass}>{t.errorBody}</p>}
-			</div>
+				{status === "error" && <FieldError>{t.errorBody}</FieldError>}
+			</Field>
 
 			<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
 				<Button type="button" variant="outline" onClick={onClose} disabled={submitting}>

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -1,0 +1,223 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { useMemo } from "react";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+	return (
+		<fieldset
+			data-slot="field-set"
+			className={cn(
+				"flex flex-col gap-6 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function FieldLegend({
+	className,
+	variant = "legend",
+	...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+	return (
+		<legend
+			data-slot="field-legend"
+			data-variant={variant}
+			className={cn(
+				"mb-3 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="field-group"
+			className={cn(
+				"group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+const fieldVariants = cva("group/field flex w-full gap-3 data-[invalid=true]:text-destructive", {
+	variants: {
+		orientation: {
+			vertical: "flex-col *:w-full [&>.sr-only]:w-auto",
+			horizontal:
+				"flex-row items-center has-[>[data-slot=field-content]]:items-start *:data-[slot=field-label]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+			responsive:
+				"flex-col *:w-full @md/field-group:flex-row @md/field-group:items-center @md/field-group:*:w-auto @md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:*:data-[slot=field-label]:flex-auto [&>.sr-only]:w-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+		},
+	},
+	defaultVariants: {
+		orientation: "vertical",
+	},
+});
+
+function Field({
+	className,
+	orientation = "vertical",
+	...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+	return (
+		// biome-ignore lint/a11y/useSemanticElements: ignore
+		<div
+			role="group"
+			data-slot="field"
+			data-orientation={orientation}
+			className={cn(fieldVariants({ orientation }), className)}
+			{...props}
+		/>
+	);
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="field-content"
+			className={cn("group/field-content flex flex-1 flex-col gap-1 leading-snug", className)}
+			{...props}
+		/>
+	);
+}
+
+function FieldLabel({ className, ...props }: React.ComponentProps<typeof Label>) {
+	return (
+		<Label
+			data-slot="field-label"
+			className={cn(
+				"group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border *:data-[slot=field]:p-3 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10",
+				"has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="field-label"
+			className={cn(
+				"flex w-fit items-center gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+	return (
+		<p
+			data-slot="field-description"
+			className={cn(
+				"text-left text-sm leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
+				"last:mt-0 nth-last-2:-mt-1",
+				"[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function FieldSeparator({
+	children,
+	className,
+	...props
+}: React.ComponentProps<"div"> & {
+	children?: React.ReactNode;
+}) {
+	return (
+		<div
+			data-slot="field-separator"
+			data-content={!!children}
+			className={cn(
+				"relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+				className,
+			)}
+			{...props}
+		>
+			<Separator className="absolute inset-0 top-1/2" />
+			{children && (
+				<span
+					className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+					data-slot="field-separator-content"
+				>
+					{children}
+				</span>
+			)}
+		</div>
+	);
+}
+
+function FieldError({
+	className,
+	children,
+	errors,
+	...props
+}: React.ComponentProps<"div"> & {
+	errors?: Array<{ message?: string } | undefined>;
+}) {
+	const content = useMemo(() => {
+		if (children) {
+			return children;
+		}
+
+		if (!errors?.length) {
+			return null;
+		}
+
+		const uniqueErrors = [...new Map(errors.map((error) => [error?.message, error])).values()];
+
+		if (uniqueErrors?.length === 1) {
+			return uniqueErrors[0]?.message;
+		}
+
+		return (
+			<ul className="ml-4 flex list-disc flex-col gap-1">
+				{/** biome-ignore lint/suspicious/noArrayIndexKey: ignore */}
+				{uniqueErrors.map((error, index) => error?.message && <li key={index}>{error.message}</li>)}
+			</ul>
+		);
+	}, [children, errors]);
+
+	if (!content) {
+		return null;
+	}
+
+	return (
+		<div
+			role="alert"
+			data-slot="field-error"
+			className={cn("text-sm font-normal text-destructive", className)}
+			{...props}
+		>
+			{content}
+		</div>
+	);
+}
+
+export {
+	Field,
+	FieldContent,
+	FieldDescription,
+	FieldError,
+	FieldGroup,
+	FieldLabel,
+	FieldLegend,
+	FieldSeparator,
+	FieldSet,
+	FieldTitle,
+};

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -1,0 +1,146 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		// biome-ignore lint/a11y/useSemanticElements: ignore
+		<div
+			data-slot="input-group"
+			role="group"
+			className={cn(
+				"group/input-group relative flex h-9 w-full min-w-0 items-center rounded-md border border-input shadow-xs transition-[color,box-shadow] outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:bg-input/30 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+const inputGroupAddonVariants = cva(
+	"flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+	{
+		variants: {
+			align: {
+				"inline-start": "order-first pl-2 has-[>button]:-ml-1 has-[>kbd]:ml-[-0.15rem]",
+				"inline-end": "order-last pr-2 has-[>button]:-mr-1 has-[>kbd]:mr-[-0.15rem]",
+				"block-start":
+					"order-first w-full justify-start px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2",
+				"block-end":
+					"order-last w-full justify-start px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2",
+			},
+		},
+		defaultVariants: {
+			align: "inline-start",
+		},
+	},
+);
+
+function InputGroupAddon({
+	className,
+	align = "inline-start",
+	...props
+}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+	return (
+		// biome-ignore lint/a11y/useKeyWithClickEvents: ignore
+		// biome-ignore lint/a11y/useSemanticElements: ignore
+		<div
+			role="group"
+			data-slot="input-group-addon"
+			data-align={align}
+			className={cn(inputGroupAddonVariants({ align }), className)}
+			onClick={(e) => {
+				if ((e.target as HTMLElement).closest("button")) {
+					return;
+				}
+				e.currentTarget.parentElement?.querySelector("input")?.focus();
+			}}
+			{...props}
+		/>
+	);
+}
+
+const inputGroupButtonVariants = cva("flex items-center gap-2 text-sm shadow-none", {
+	variants: {
+		size: {
+			xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+			sm: "",
+			"icon-xs": "size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0",
+			"icon-sm": "size-8 p-0 has-[>svg]:p-0",
+		},
+	},
+	defaultVariants: {
+		size: "xs",
+	},
+});
+
+function InputGroupButton({
+	className,
+	type = "button",
+	variant = "ghost",
+	size = "xs",
+	...props
+}: Omit<React.ComponentProps<typeof Button>, "size" | "type"> &
+	VariantProps<typeof inputGroupButtonVariants> & {
+		type?: "button" | "submit" | "reset";
+	}) {
+	return (
+		<Button
+			type={type}
+			data-size={size}
+			variant={variant}
+			className={cn(inputGroupButtonVariants({ size }), className)}
+			{...props}
+		/>
+	);
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+	return (
+		<span
+			className={cn(
+				"flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function InputGroupInput({ className, ...props }: React.ComponentProps<"input">) {
+	return (
+		<Input
+			data-slot="input-group-control"
+			className={cn(
+				"flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function InputGroupTextarea({ className, ...props }: React.ComponentProps<"textarea">) {
+	return (
+		<Textarea
+			data-slot="input-group-control"
+			className={cn(
+				"flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupButton,
+	InputGroupInput,
+	InputGroupText,
+	InputGroupTextarea,
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import { Input as InputPrimitive } from "@base-ui/react/input";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+	return (
+		<InputPrimitive
+			type={type}
+			data-slot="input"
+			className={cn(
+				"h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,19 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+	return (
+		// biome-ignore lint/a11y/noLabelWithoutControl: ignore
+		<label
+			data-slot="label"
+			className={cn(
+				"flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export { Label };

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
+
+import { cn } from "@/lib/utils";
+
+function Separator({ className, orientation = "horizontal", ...props }: SeparatorPrimitive.Props) {
+	return (
+		<SeparatorPrimitive
+			data-slot="separator"
+			orientation={orientation}
+			className={cn(
+				"shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export { Separator };

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,16 @@
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+	return (
+		<textarea
+			data-slot="textarea"
+			className={cn(
+				"flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-2.5 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export { Textarea };


### PR DESCRIPTION
## What

Refactors the contact form to use the shared `Field` and `InputGroup` UI
primitives instead of hand-rolled `label`/`input` markup and ad-hoc class
strings.

## Changes

- `contact-form.tsx` — name / email / subject now use `Field` + `FieldLabel` + `InputGroup` (with addon icons) + `FieldError`; the rich-text message and Turnstile blocks are wrapped in `Field` too. Removes the local `fieldClass` / `labelClass` / `errorClass` strings.
- Adds the supporting `ui` primitives: `field`, `input-group`, `input`, `textarea`, `label`, `separator`.

## Notes

- Behaviour and validation are unchanged; this is markup/structure only.
- `pnpm check` passes with 0 errors.