### PR TITLE
feat(dock): add guestbook to nav

### DIFF
--- a/src/components/shared/dock/dock-bar.tsx
+++ b/src/components/shared/dock/dock-bar.tsx
@@ -1,6 +1,6 @@
 import { RestrictToWindow } from "@dnd-kit/dom/modifiers";
 import { useDraggable } from "@dnd-kit/react";
-import { Grip, HomeIcon, NotebookText, Radio } from "lucide-react";
+import { Grip, HomeIcon, MessagesSquare, NotebookText, Radio } from "lucide-react";
 import { motion } from "motion/react";
 import { useMotionEnabled } from "@/hooks/use-motion";
 import type { Lang } from "@/i18n/config";
@@ -135,6 +135,16 @@ export function DockBar({
 							current={path.startsWith("/now")}
 						>
 							<Radio className="size-4" />
+						</DockLink>
+					</li>
+
+					<li className="max-sm:hidden">
+						<DockLink
+							href={localizePath("/guestbook", lang)}
+							label={nav.guestbook}
+							current={path.startsWith("/guestbook")}
+						>
+							<MessagesSquare className="size-4" />
 						</DockLink>
 					</li>
 

--- a/src/components/shared/dock/dock-menu-pages.tsx
+++ b/src/components/shared/dock/dock-menu-pages.tsx
@@ -1,6 +1,6 @@
 import { Menu as MenuPrimitive } from "@base-ui/react/menu";
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
-import { Files, NotebookText, Radio } from "lucide-react";
+import { Files, MessagesSquare, NotebookText, Radio } from "lucide-react";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -15,12 +15,13 @@ import { localizePath, stripLocale } from "@/i18n/utils";
 import { cn } from "@/lib/utils";
 import { itemClass } from "./constants";
 
-/** Mobile-only dropdown of the standalone pages (Notes, Now). */
+/** Mobile-only dropdown of the standalone pages (Notes, Now, Guestbook). */
 export function DockMenuPages({ pathname, lang }: { pathname: string; lang: Lang }) {
 	const nav = getDictionary(lang).nav;
 	const path = stripLocale(pathname);
 	const onNotes = path.startsWith("/notes");
 	const onNow = path.startsWith("/now");
+	const onGuestbook = path.startsWith("/guestbook");
 
 	return (
 		<DropdownMenu modal={false}>
@@ -32,7 +33,10 @@ export function DockMenuPages({ pathname, lang }: { pathname: string; lang: Lang
 								<button
 									type="button"
 									aria-label={nav.availablePages}
-									className={cn(itemClass, (onNotes || onNow) && "bg-muted text-foreground")}
+									className={cn(
+										itemClass,
+										(onNotes || onNow || onGuestbook) && "bg-muted text-foreground",
+									)}
 								>
 									<Files className="size-4" />
 								</button>
@@ -57,6 +61,12 @@ export function DockMenuPages({ pathname, lang }: { pathname: string; lang: Lang
 						aria-current={onNow ? "page" : undefined}
 					>
 						<Radio className="size-4" /> {nav.now}
+					</DropdownMenuLinkItem>
+					<DropdownMenuLinkItem
+						href={localizePath("/guestbook", lang)}
+						aria-current={onGuestbook ? "page" : undefined}
+					>
+						<MessagesSquare className="size-4" /> {nav.guestbook}
 					</DropdownMenuLinkItem>
 				</DropdownMenuGroup>
 			</DropdownMenuContent>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -9,6 +9,7 @@ export const en = {
 		home: "Home",
 		notes: "Notes",
 		now: "Now",
+		guestbook: "Guestbook",
 		dragToMove: "Drag to move",
 		hideDock: "Hide dock",
 		pages: "Pages",

--- a/src/i18n/id.ts
+++ b/src/i18n/id.ts
@@ -11,6 +11,7 @@ export const id: Dictionary = {
 		home: "Beranda",
 		notes: "Catatan",
 		now: "Now",
+		guestbook: "Buku Tamu",
 		dragToMove: "Geser untuk memindahkan",
 		hideDock: "Sembunyikan dock",
 		pages: "Halaman",


### PR DESCRIPTION
Adds Guestbook to the dock, following the exact notes/now responsive pattern:

- **Tablet / desktop (≥640px):** a standalone dock link (`MessagesSquare` icon), placed after *Now* — `max-sm:hidden`.
- **Mobile (<640px):** lives inside the **Pages** dropdown (`sm:hidden`) alongside Home/Notes/Now, and the dropdown's active state now also lights up on `/guestbook`.
- Adds the `nav.guestbook` label (en: "Guestbook", id: "Buku Tamu"); links are locale-aware via `localizePath`.

`pnpm check` 0/0 and the build (22 pages) pass.