### PR TITLE
fix(guestbook): redirect back to page on OAuth cancel

### DIFF
--- a/src/components/home/guestbook/guestbook-button.tsx
+++ b/src/components/home/guestbook/guestbook-button.tsx
@@ -10,6 +10,7 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@/components/ui/dialog";
+import { useClearAuthError } from "@/hooks/use-clear-auth-error";
 import type { Lang } from "@/i18n/config";
 import { getDictionary } from "@/i18n/dictionary";
 import { getQueryClient } from "@/lib/query-client";
@@ -23,6 +24,7 @@ type GuestbookButtonProps = { lang: Lang; siteKey: string };
 export function GuestbookButton(props: GuestbookButtonProps) {
 	const t = getDictionary(props.lang).guestbook;
 	const [open, setOpen] = useState(false);
+	useClearAuthError();
 
 	return (
 		<QueryClientProvider client={getQueryClient()}>

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -9,10 +9,10 @@ export function useAuth() {
 	const session = authClient.useSession();
 
 	function login(provider: AuthProvider) {
-		authClient.signIn.social({
-			provider,
-			callbackURL: window.location.pathname + window.location.search,
-		});
+		const returnTo = window.location.pathname + window.location.search;
+		// Denying/canceling consent → come back to the page instead of better-auth's
+		// error page. The ?error param is stripped on load by useClearAuthError().
+		authClient.signIn.social({ provider, callbackURL: returnTo, errorCallbackURL: returnTo });
 	}
 
 	async function signOut() {

--- a/src/hooks/use-clear-auth-error.ts
+++ b/src/hooks/use-clear-auth-error.ts
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+
+// A canceled/denied OAuth redirect returns with ?error=... appended. Strip it so
+// the address bar doesn't keep the error string after we're back on the page.
+export function useClearAuthError() {
+	useEffect(() => {
+		const url = new URL(window.location.href);
+		if (!url.searchParams.has("error")) return;
+		url.searchParams.delete("error");
+		url.searchParams.delete("error_description");
+		window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
+	}, []);
+}


### PR DESCRIPTION
## What

Canceling/denying OAuth consent currently dumps the user on better-auth's error page (`/api/auth/error?error=access_denied&...`). This returns them to the page they started from instead.

## How

- Pass `errorCallbackURL` (the current path + query, so it's locale-aware) to `signIn.social`. better-auth stores it in the OAuth state and redirects there on a provider `error` instead of the default `/api/auth/error`.
- `useClearAuthError()` strips the appended `?error`/`?error_description` params on load via `history.replaceState`, so the address bar stays clean after the bounce. Called from `GuestbookButton` (eagerly mounted on `/guestbook`, where auth is initiated).

## Test

- `pnpm check` → 0 errors.
- Manual: click a provider → deny consent → lands back on `/guestbook` with a clean URL.