### PR TITLE
fix(markdown): migrate deprecated plugin config to unified() processor

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,3 +1,4 @@
+import { unified } from "@astrojs/markdown-remark";
 import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
@@ -58,7 +59,7 @@ export default defineConfig({
 			themes: { light: "github-light-default", dark: "github-dark-default" },
 			wrap: true,
 		},
-		rehypePlugins: [rehypeSlug, rehypeAutolinkHeadings],
+		processor: unified({ rehypePlugins: [rehypeSlug, rehypeAutolinkHeadings] }),
 	},
 	integrations: [
 		react(),

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"guestbook:preview": "wrangler d1 migrations apply guestbook --local && astro sync && astro build && wrangler pages dev dist"
 	},
 	"dependencies": {
+		"@astrojs/markdown-remark": "^7.2.0",
 		"@astrojs/mdx": "^7.0.0",
 		"@astrojs/react": "^6.0.0",
 		"@astrojs/sitemap": "^3.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@astrojs/markdown-remark':
+        specifier: ^7.2.0
+        version: 7.2.0
       '@astrojs/mdx':
         specifier: ^7.0.0
         version: 7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))


### PR DESCRIPTION
## Summary

Astro 7 made Sätteri the default Markdown processor and deprecated the top-level `markdown.remarkPlugins` / `rehypePlugins` / `remarkRehype` options, emitting this on every dev/build:

> [astro] `markdown.remarkPlugins`, `markdown.rehypePlugins`, and `markdown.remarkRehype` are deprecated. Pass them to `unified({...})` from `@astrojs/markdown-remark` directly instead.

- Move `rehypePlugins: [rehypeSlug, rehypeAutolinkHeadings]` onto `markdown.processor: unified({...})` from `@astrojs/markdown-remark`
- Add `@astrojs/markdown-remark` as a direct dependency — it's no longer part of Astro's default install (optional peer only), so the config import needs an explicit dep under pnpm
- `syntaxHighlight` / `shikiConfig` are unchanged; those still live at the `markdown.*` level

`@astrojs/mdx` v7 inherits plugins from a `unified()` processor automatically (`extendMarkdownConfig`), so MDX content keeps the same pipeline.

## Verification

- `astro sync` and `astro build` run with no deprecation warning
- Built notes still have slugged headings (`<h2 id="using-jotai">`) and autolinked anchors (`<a href="#using-jotai">`), confirming both rehype plugins still run through the new processor