### PR TITLE
fix(guestbook): stack page header on mobile, full-width write button

### DIFF
--- a/src/components/home/guestbook/guestbook-button.tsx
+++ b/src/components/home/guestbook/guestbook-button.tsx
@@ -14,12 +14,13 @@ import { useClearAuthError } from "@/hooks/use-clear-auth-error";
 import type { Lang } from "@/i18n/config";
 import { getDictionary } from "@/i18n/dictionary";
 import { getQueryClient } from "@/lib/query-client";
+import { cn } from "@/lib/utils";
 
 const GuestbookCompose = lazy(() =>
 	import("./guestbook-compose").then((m) => ({ default: m.GuestbookCompose })),
 );
 
-type GuestbookButtonProps = { lang: Lang; siteKey: string };
+type GuestbookButtonProps = { lang: Lang; siteKey: string; className?: string };
 
 export function GuestbookButton(props: GuestbookButtonProps) {
 	const t = getDictionary(props.lang).guestbook;
@@ -29,7 +30,7 @@ export function GuestbookButton(props: GuestbookButtonProps) {
 	return (
 		<QueryClientProvider client={getQueryClient()}>
 			<Dialog open={open} onOpenChange={setOpen}>
-				<DialogTrigger render={<Button />}>
+				<DialogTrigger render={<Button className={cn("max-sm:w-full", props.className)} />}>
 					<Plus />
 					{t.write}
 				</DialogTrigger>

--- a/src/components/home/guestbook/guestbook-page.astro
+++ b/src/components/home/guestbook/guestbook-page.astro
@@ -10,7 +10,7 @@ import { GuestbookButton } from "./guestbook-button";
 import { GuestbookFeed } from "./guestbook-feed";
 
 interface Props {
-	lang: Lang;
+  lang: Lang;
 }
 
 const { lang } = Astro.props;
@@ -22,19 +22,28 @@ const initial = await getRecentCommentsAtBuild(10);
   <Seo slot="metadata" title={t.seoTitle} description={t.description} />
 
   <Section class="pt-12 pb-16 lg:pt-24">
-    <div class="flex items-start justify-between gap-4 pb-8">
+    <div
+      class="flex flex-col gap-6 pb-8 sm:flex-row sm:justify-between sm:gap-4"
+    >
       <div>
         <h1
           class="text-4xl leading-none font-bold tracking-tight text-balance sm:text-5xl lg:text-6xl"
         >
           {t.heading}
         </h1>
-        <p class="max-w-2xl pt-4 text-pretty text-muted-foreground lg:pt-6 lg:text-lg">
+        <p
+          class="max-w-2xl pt-4 text-pretty text-muted-foreground lg:pt-6 lg:text-lg"
+        >
           {t.description}
         </p>
       </div>
 
-      <GuestbookButton client:visible lang={lang} siteKey={PUBLIC_CF_TURNSTILE_SITE_KEY} />
+      <GuestbookButton
+        lang={lang}
+        client:visible
+        className="sm:mt-3"
+        siteKey={PUBLIC_CF_TURNSTILE_SITE_KEY}
+      />
     </div>
 
     <GuestbookFeed


### PR DESCRIPTION
## Summary

On the standalone guestbook page, the "Write message" button sat inline beside the heading in a `justify-between` row — too tight on mobile, squeezing the heading.

- Stack the page header vertically below the `sm` breakpoint; the side-by-side layout returns at `sm:` and up (with `sm:mt-3` to align the button against the larger heading)
- Make the trigger button full-width on mobile (`max-sm:w-full`), threaded through a new optional `className` prop on `GuestbookButton`

Desktop layout is unchanged.