### PR TITLE
feat(guestbook): render compose as drawer on mobile, dialog on desktop

### DIFF
--- a/src/components/home/guestbook/guestbook-button.tsx
+++ b/src/components/home/guestbook/guestbook-button.tsx
@@ -10,7 +10,16 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+	Drawer,
+	DrawerContent,
+	DrawerDescription,
+	DrawerHeader,
+	DrawerTitle,
+	DrawerTrigger,
+} from "@/components/ui/drawer";
 import { useClearAuthError } from "@/hooks/use-clear-auth-error";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import type { Lang } from "@/i18n/config";
 import { getDictionary } from "@/i18n/dictionary";
 import { getQueryClient } from "@/lib/query-client";
@@ -25,7 +34,41 @@ type GuestbookButtonProps = { lang: Lang; siteKey: string; className?: string };
 export function GuestbookButton(props: GuestbookButtonProps) {
 	const t = getDictionary(props.lang).guestbook;
 	const [open, setOpen] = useState(false);
+	const isMobile = useIsMobile();
 	useClearAuthError();
+
+	// The forms inside reuse DialogClose/DialogFooter in both branches — Base UI's
+	// drawer is built on the dialog store, so DialogClose works inside a Drawer.
+	const compose = (
+		<Suspense fallback={null}>
+			<GuestbookCompose
+				lang={props.lang}
+				siteKey={props.siteKey}
+				onSuccess={() => setOpen(false)}
+			/>
+		</Suspense>
+	);
+
+	if (isMobile) {
+		return (
+			<QueryClientProvider client={getQueryClient()}>
+				<Drawer open={open} onOpenChange={setOpen}>
+					<DrawerTrigger render={<Button className={cn("max-sm:w-full", props.className)} />}>
+						<Plus />
+						{t.write}
+					</DrawerTrigger>
+
+					<DrawerContent>
+						<DrawerHeader className="text-left">
+							<DrawerTitle>{t.dialog.title}</DrawerTitle>
+							<DrawerDescription className="text-balance">{t.dialog.description}</DrawerDescription>
+						</DrawerHeader>
+						<div className="px-4 pb-2">{compose}</div>
+					</DrawerContent>
+				</Drawer>
+			</QueryClientProvider>
+		);
+	}
 
 	return (
 		<QueryClientProvider client={getQueryClient()}>
@@ -40,14 +83,7 @@ export function GuestbookButton(props: GuestbookButtonProps) {
 						<DialogTitle>{t.dialog.title}</DialogTitle>
 						<DialogDescription className="text-balance">{t.dialog.description}</DialogDescription>
 					</DialogHeader>
-
-					<Suspense fallback={null}>
-						<GuestbookCompose
-							lang={props.lang}
-							siteKey={props.siteKey}
-							onSuccess={() => setOpen(false)}
-						/>
-					</Suspense>
+					{compose}
 				</DialogContent>
 			</Dialog>
 		</QueryClientProvider>


### PR DESCRIPTION
## Summary

Make the guestbook compose responsive like the contact dialog: a bottom drawer below `sm` (640px), the existing centered dialog on desktop.

- Switch on the same `useIsMobile()` hook `ContactDialog` uses; the drawer branch mirrors contact's markup (`text-left` header, `text-balance` description, `px-4 pb-2` body)
- The shared `<GuestbookCompose>` (Suspense wrapper + close-on-success) is built once and rendered in whichever container is active
- No changes needed in the inner forms: Base UI's `Drawer.Close` **is** `Dialog.Close` (the drawer is built on the dialog store), so the existing `DialogClose`/`DialogFooter` in `GuestbookForm` / `GuestbookVerifiedForm` work identically inside the drawer