### PR TITLE
feat(agents): agent discovery — Link headers, API catalog, OpenAPI, agent skills

### DIFF
--- a/functions/api/health.ts
+++ b/functions/api/health.ts
@@ -1,0 +1,8 @@
+// Liveness endpoint, advertised as the `status` link in /.well-known/api-catalog
+// (RFC 9727) so agents can check the API before calling it.
+export async function onRequestGet(): Promise<Response> {
+	return new Response(JSON.stringify({ status: "ok" }), {
+		status: 200,
+		headers: { "content-type": "application/json", "cache-control": "no-store" },
+	});
+}

--- a/public/.well-known/agent-skills/guestbook/SKILL.md
+++ b/public/.well-known/agent-skills/guestbook/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: guestbook
+description: Read and sign the guestbook at rimzzlabs.com. Use when you want to browse what visitors wrote, or leave a message on behalf of your user.
+---
+
+# rimzzlabs.com guestbook
+
+The guestbook is a public comment feed. **Reading is open to any HTTP client.**
+**Writing requires a human in the loop** — either a Cloudflare Turnstile token
+(anonymous) or a GitHub/Google OAuth browser session (verified). This is
+deliberate bot protection: if you are a fully headless agent, you can read but
+not post; if you control a browser, you can do both.
+
+Full API contract: https://rimzzlabs.com/openapi.json
+
+## Read the feed
+
+```
+GET https://rimzzlabs.com/api/guestbook?offset=0&limit=10
+```
+
+- `limit`: 1–50 (default 10), `offset`: ≥ 0 (default 0).
+- Returns `{ "items": [...], "nextOffset": 10 }`; `nextOffset` is `null` on the
+  last page. Pass it as the next `offset` to paginate.
+- Each item: `id`, `name`, `site`, `message`, `createdAt`/`updatedAt` (epoch ms),
+  `authorType` (`"anon" | "github" | "google"`), `avatar`, `isOwn`.
+
+## Post a message (browser required)
+
+Preferred: navigate to https://rimzzlabs.com/guestbook and use the "Write
+message" button — the page handles Turnstile and OAuth for you.
+
+Direct API, anonymous mode:
+
+```
+POST https://rimzzlabs.com/api/guestbook
+Content-Type: application/json
+
+{ "name": "Ada", "site": "https://example.com", "message": "Hello!", "token": "<turnstile-token>" }
+```
+
+- `token` is a Cloudflare Turnstile response token; it can only be obtained by
+  rendering the Turnstile widget in a real browser on this site.
+- Limits: `name` ≤ 100 chars, `site` ≤ 200 (optional), `message` ≤ 500.
+- A `201` response sets an HttpOnly `gb_owner` cookie. Keep it: it authorizes
+  `PATCH`/`DELETE https://rimzzlabs.com/api/guestbook/{id}` on your own comments.
+
+Signed-in mode: establish a session via GitHub/Google OAuth at
+`/api/auth/sign-in/social` (browser flow), then POST just
+`{ "site"?, "message" }` — the name comes from the OAuth profile.
+
+## Errors
+
+`400` invalid JSON or input, `403` Turnstile failed / not your comment,
+`404` comment not found. Error body: `{ "error": "<code>" }`.

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+	"skills": [
+		{
+			"name": "guestbook",
+			"type": "skill-md",
+			"description": "Read and sign the rimzzlabs.com guestbook. Reading is open to any HTTP client; posting requires a browser (Cloudflare Turnstile or GitHub/Google OAuth).",
+			"url": "/.well-known/agent-skills/guestbook/SKILL.md",
+			"digest": "sha256:f45acfc75162ed02a68186e2e53b011f217d72a25516033f507727feac6e4501"
+		}
+	]
+}

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,24 @@
+{
+	"linkset": [
+		{
+			"anchor": "https://rimzzlabs.com/api/guestbook",
+			"service-desc": [
+				{ "href": "https://rimzzlabs.com/openapi.json", "type": "application/json" }
+			],
+			"service-doc": [
+				{
+					"href": "https://rimzzlabs.com/.well-known/agent-skills/guestbook/SKILL.md",
+					"type": "text/markdown"
+				}
+			],
+			"status": [{ "href": "https://rimzzlabs.com/api/health" }]
+		},
+		{
+			"anchor": "https://rimzzlabs.com/api/contact",
+			"service-desc": [
+				{ "href": "https://rimzzlabs.com/openapi.json", "type": "application/json" }
+			],
+			"status": [{ "href": "https://rimzzlabs.com/api/health" }]
+		}
+	]
+}

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,14 @@
+# Cloudflare Pages headers (copied to dist/ by Astro from public/).
+# https://developers.cloudflare.com/pages/configuration/headers/
+
+# Agent discovery (RFC 8288 + RFC 9727): advertise the API catalog on every page.
+/*
+  Link: </.well-known/api-catalog>; rel="api-catalog"
+
+# RFC 9727 requires the linkset media type; Pages would otherwise guess none.
+/.well-known/api-catalog
+  Content-Type: application/linkset+json
+
+# Serve agent skills as markdown, not octet-stream.
+/.well-known/agent-skills/*/SKILL.md
+  Content-Type: text/markdown; charset=utf-8

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1,0 +1,316 @@
+{
+	"openapi": "3.1.0",
+	"info": {
+		"title": "rimzzlabs.com API",
+		"version": "1.0.0",
+		"description": "Public API behind rimzzlabs.com: a guestbook (read open to everyone, writes protected by Cloudflare Turnstile or a browser OAuth session) and a contact form. Advertised for discovery via /.well-known/api-catalog (RFC 9727).",
+		"contact": { "name": "Rizki Citra", "url": "https://rimzzlabs.com" }
+	},
+	"servers": [{ "url": "https://rimzzlabs.com" }],
+	"paths": {
+		"/api/health": {
+			"get": {
+				"operationId": "getHealth",
+				"summary": "API liveness check",
+				"responses": {
+					"200": {
+						"description": "API is up",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": { "status": { "type": "string", "const": "ok" } },
+									"required": ["status"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/guestbook": {
+			"get": {
+				"operationId": "listGuestbookComments",
+				"summary": "List guestbook comments, newest first",
+				"parameters": [
+					{
+						"name": "offset",
+						"in": "query",
+						"schema": { "type": "integer", "minimum": 0, "default": 0 }
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"schema": { "type": "integer", "minimum": 1, "maximum": 50, "default": 10 }
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "One page of comments. `nextOffset` is null on the last page.",
+						"content": {
+							"application/json": { "schema": { "$ref": "#/components/schemas/GuestbookPage" } }
+						}
+					}
+				}
+			},
+			"post": {
+				"operationId": "createGuestbookComment",
+				"summary": "Post a guestbook comment",
+				"description": "Two modes. Anonymous: send name, message, and a Cloudflare Turnstile token (obtainable only by rendering the Turnstile widget in a real browser); the response sets an HttpOnly `gb_owner` cookie that authorizes later edits/deletes of your own comments. Signed-in (browser session cookie from GitHub/Google OAuth via /api/auth): send only message and optional site; the author name comes from the OAuth profile. Fully headless clients cannot post — this is intentional bot protection; reading is unrestricted.",
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"oneOf": [
+									{ "$ref": "#/components/schemas/AnonymousCommentInput" },
+									{ "$ref": "#/components/schemas/VerifiedCommentInput" }
+								]
+							}
+						}
+					}
+				},
+				"responses": {
+					"201": {
+						"description": "Comment created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": { "item": { "$ref": "#/components/schemas/GuestbookComment" } },
+									"required": ["item"]
+								}
+							}
+						}
+					},
+					"400": { "$ref": "#/components/responses/BadRequest" },
+					"403": {
+						"description": "Turnstile verification failed",
+						"content": {
+							"application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
+						}
+					}
+				}
+			}
+		},
+		"/api/guestbook/{id}": {
+			"parameters": [
+				{
+					"name": "id",
+					"in": "path",
+					"required": true,
+					"schema": { "type": "integer", "minimum": 1 }
+				}
+			],
+			"patch": {
+				"operationId": "editGuestbookComment",
+				"summary": "Edit your own comment",
+				"description": "Authorized by the `gb_owner` cookie (anonymous authors) or the OAuth session cookie (verified authors). Anonymous authors may change their name; verified authors keep the provider name.",
+				"security": [{ "ownerCookie": [] }, { "sessionCookie": [] }],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"oneOf": [
+									{ "$ref": "#/components/schemas/AnonymousEditInput" },
+									{ "$ref": "#/components/schemas/VerifiedCommentInput" }
+								]
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Updated comment",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": { "item": { "$ref": "#/components/schemas/GuestbookComment" } },
+									"required": ["item"]
+								}
+							}
+						}
+					},
+					"400": { "$ref": "#/components/responses/BadRequest" },
+					"403": { "$ref": "#/components/responses/Forbidden" },
+					"404": { "$ref": "#/components/responses/NotFound" }
+				}
+			},
+			"delete": {
+				"operationId": "deleteGuestbookComment",
+				"summary": "Delete your own comment",
+				"security": [{ "ownerCookie": [] }, { "sessionCookie": [] }],
+				"responses": {
+					"200": {
+						"description": "Deleted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": { "ok": { "type": "boolean", "const": true } },
+									"required": ["ok"]
+								}
+							}
+						}
+					},
+					"403": { "$ref": "#/components/responses/Forbidden" },
+					"404": { "$ref": "#/components/responses/NotFound" }
+				}
+			}
+		},
+		"/api/contact": {
+			"post": {
+				"operationId": "sendContactMessage",
+				"summary": "Send a message to the site owner",
+				"description": "Delivers an email via the contact form pipeline. Requires a Cloudflare Turnstile token, so it can only be completed from a real browser.",
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": { "schema": { "$ref": "#/components/schemas/ContactInput" } }
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Message sent",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": { "ok": { "type": "boolean", "const": true } },
+									"required": ["ok"]
+								}
+							}
+						}
+					},
+					"400": { "$ref": "#/components/responses/BadRequest" },
+					"403": {
+						"description": "Turnstile verification failed",
+						"content": {
+							"application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
+						}
+					},
+					"502": {
+						"description": "Email delivery failed",
+						"content": {
+							"application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
+						}
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"securitySchemes": {
+			"ownerCookie": {
+				"type": "apiKey",
+				"in": "cookie",
+				"name": "gb_owner",
+				"description": "HttpOnly cookie set when posting an anonymous comment; proves ownership for edits and deletes."
+			},
+			"sessionCookie": {
+				"type": "apiKey",
+				"in": "cookie",
+				"name": "better-auth.session_token",
+				"description": "Browser session established via GitHub or Google OAuth at /api/auth. There is no client-credentials or device flow — sign-in requires a browser."
+			}
+		},
+		"responses": {
+			"BadRequest": {
+				"description": "Invalid JSON or input failed validation",
+				"content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+			},
+			"Forbidden": {
+				"description": "You do not own this comment",
+				"content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+			},
+			"NotFound": {
+				"description": "Comment not found",
+				"content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+			}
+		},
+		"schemas": {
+			"Error": {
+				"type": "object",
+				"properties": { "error": { "type": "string" } },
+				"required": ["error"]
+			},
+			"GuestbookComment": {
+				"type": "object",
+				"properties": {
+					"id": { "type": "integer" },
+					"name": { "type": "string" },
+					"site": { "type": ["string", "null"] },
+					"message": { "type": "string" },
+					"createdAt": { "type": "integer", "description": "Unix epoch milliseconds" },
+					"updatedAt": { "type": ["integer", "null"], "description": "Unix epoch milliseconds" },
+					"authorType": { "type": "string", "enum": ["anon", "github", "google"] },
+					"avatar": { "type": ["string", "null"] },
+					"isOwn": { "type": "boolean" }
+				},
+				"required": [
+					"id",
+					"name",
+					"site",
+					"message",
+					"createdAt",
+					"updatedAt",
+					"authorType",
+					"avatar",
+					"isOwn"
+				]
+			},
+			"GuestbookPage": {
+				"type": "object",
+				"properties": {
+					"items": {
+						"type": "array",
+						"items": { "$ref": "#/components/schemas/GuestbookComment" }
+					},
+					"nextOffset": { "type": ["integer", "null"] }
+				},
+				"required": ["items", "nextOffset"]
+			},
+			"AnonymousCommentInput": {
+				"type": "object",
+				"properties": {
+					"name": { "type": "string", "minLength": 1, "maxLength": 100 },
+					"site": { "type": "string", "maxLength": 200 },
+					"message": { "type": "string", "minLength": 1, "maxLength": 500 },
+					"token": { "type": "string", "description": "Cloudflare Turnstile response token" }
+				},
+				"required": ["name", "message", "token"]
+			},
+			"AnonymousEditInput": {
+				"type": "object",
+				"properties": {
+					"name": { "type": "string", "minLength": 1, "maxLength": 100 },
+					"site": { "type": "string", "maxLength": 200 },
+					"message": { "type": "string", "minLength": 1, "maxLength": 500 }
+				},
+				"required": ["name", "message"]
+			},
+			"VerifiedCommentInput": {
+				"type": "object",
+				"properties": {
+					"site": { "type": "string", "maxLength": 200 },
+					"message": { "type": "string", "minLength": 1, "maxLength": 500 }
+				},
+				"required": ["message"]
+			},
+			"ContactInput": {
+				"type": "object",
+				"properties": {
+					"name": { "type": "string", "minLength": 1, "maxLength": 100 },
+					"email": { "type": "string", "format": "email", "maxLength": 200 },
+					"subject": { "type": "string", "minLength": 1, "maxLength": 200 },
+					"bodyHtml": { "type": "string", "maxLength": 20000 },
+					"bodyText": { "type": "string", "minLength": 1 },
+					"token": { "type": "string", "description": "Cloudflare Turnstile response token" }
+				},
+				"required": ["name", "email", "subject", "bodyText", "token"]
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Make the site agent-aware per the applicable subset of the isitagentready.com checklist:

- **Link headers (RFC 8288)** — `public/_headers` sends `Link: </.well-known/api-catalog>; rel="api-catalog"` on every page, plus `Content-Type` overrides for the new well-known files (`application/linkset+json`, `text/markdown`)
- **API catalog (RFC 9727)** — `/.well-known/api-catalog` linkset describing the guestbook and contact APIs with `service-desc`, `service-doc`, and `status` links
- **OpenAPI 3.1 spec** at `/openapi.json` documenting the real API surface (pagination, zod field limits, `gb_owner` ownership cookie, error codes), plus a new `/api/health` liveness endpoint as the catalog's status target
- **Agent skills discovery** — `/.well-known/agent-skills/index.json` (Agent Skills Discovery RFC v0.2.0 shape) listing a `guestbook` SKILL.md that teaches agents to read the feed and explains that posting requires a browser (Turnstile/OAuth is intentional bot protection)

Deliberately **not** included: OAuth/OIDC discovery, protected-resource metadata, auth.md (no OAuth-protected APIs for third parties), MCP server card (no MCP server), WebMCP (experimental). Markdown for Agents and DNS-AID are Cloudflare dashboard actions, not repo changes.

Maintenance note: editing a SKILL.md requires recomputing its `sha256` digest in `index.json`.

## Verification

Served `dist/` through `wrangler pages dev` and curl-checked: Link header present on `/`, catalog returns `application/linkset+json`, SKILL.md returns `text/markdown`, `/api/health` returns `{"status":"ok"}`, guestbook feed unaffected. Astro copies `public/.well-known` and `public/_headers` into `dist/` verbatim.