### PR TITLE
feat(agents): serve markdown page variants via Accept: text/markdown

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,14 +1,17 @@
 // Cloudflare Pages middleware. The site is fully static; this is the only piece
-// that runs per-request. It does two things:
+// that runs per-request. It does three things:
 //   1. Root-only language detection — redirect `/` to `/id` based on a `locale`
 //      cookie, falling back to `Accept-Language`, defaulting to English.
-//   2. Locale-aware 404s — serve the `/id` not-found page for misses under `/id`.
+//   2. Markdown for agents — serve the prebuilt /md/* variant of a page when the
+//      request prefers `Accept: text/markdown`.
+//   3. Locale-aware 404s — serve the `/id` not-found page for misses under `/id`.
 
 type Locale = "en" | "id";
 
 interface MiddlewareContext {
 	request: Request;
 	next: (input?: Request | string) => Promise<Response>;
+	env: { ASSETS: { fetch: (input: Request | string) => Promise<Response> } };
 }
 
 const COOKIE_RE = /(?:^|;\s*)locale=(en|id)(?:;|$)/;
@@ -39,12 +42,58 @@ function readLocale(request: Request): Locale {
 	return detectLang(request.headers.get("accept-language"));
 }
 
+/**
+ * Markdown variants live under /md/* (built by src/pages/md), mirroring the page
+ * tree: `/` → /md/index.md, `/notes/x` → /md/notes/x.md. Outside /notes so the
+ * fuzzy-router functions never see them.
+ */
+function markdownCandidates(pathname: string): Array<string> {
+	const clean = pathname.replace(/\/+$/, "");
+	const candidates = [];
+	if (clean) candidates.push(`/md${clean}.md`);
+	candidates.push(`/md${clean}/index.md`);
+	return candidates;
+}
+
+// Probe with ASSETS.fetch, never next(url): a middleware next(url) *rewrites*
+// the in-flight request for the rest of the chain, so a missed probe would leak
+// into the real response.
+async function serveMarkdown(
+	url: URL,
+	assets: MiddlewareContext["env"]["ASSETS"],
+): Promise<Response | null> {
+	for (const candidate of markdownCandidates(url.pathname)) {
+		const asset = await assets.fetch(new URL(candidate, url).toString());
+		if (asset.status !== 200) continue;
+		const text = await asset.text();
+		return new Response(text, {
+			headers: {
+				"content-type": "text/markdown; charset=utf-8",
+				vary: "accept",
+				"x-markdown-tokens": String(Math.ceil(text.length / 4)),
+			},
+		});
+	}
+	return null;
+}
+
 export async function onRequest(context: MiddlewareContext): Promise<Response> {
-	const { request, next } = context;
+	const { request, next, env } = context;
 	const url = new URL(request.url);
 
 	if (url.pathname === "/" && readLocale(request) === "id") {
 		return new Response(null, { status: 302, headers: { Location: "/id" } });
+	}
+
+	// Markdown for agents: prefer the prebuilt markdown variant when the client
+	// asks for it. Pages that have no variant fall through to HTML.
+	const wantsMarkdown =
+		request.method === "GET" &&
+		request.headers.get("accept")?.includes("text/markdown") &&
+		!url.pathname.startsWith("/md/");
+	if (wantsMarkdown) {
+		const markdown = await serveMarkdown(url, env.ASSETS);
+		if (markdown) return markdown;
 	}
 
 	const response = await next();

--- a/public/_headers
+++ b/public/_headers
@@ -12,3 +12,9 @@
 # Serve agent skills as markdown, not octet-stream.
 /.well-known/agent-skills/*/SKILL.md
   Content-Type: text/markdown; charset=utf-8
+
+# Markdown variants of pages, served via `Accept: text/markdown` negotiation in
+# functions/_middleware.ts. Direct hits work too, but keep them out of search.
+/md/*
+  Content-Type: text/markdown; charset=utf-8
+  X-Robots-Tag: noindex

--- a/src/components/home/experience-companies.ts
+++ b/src/components/home/experience-companies.ts
@@ -1,0 +1,16 @@
+import type { Dictionary } from "@/i18n/dictionary";
+
+export type ExperienceCompany = {
+	key: keyof Dictionary["experience"]["items"];
+	company: string;
+	url: string;
+};
+
+// Shared by the experience section and the markdown (agent) variant of the
+// homepage; the localized title/period/summary live in the dictionaries.
+export const EXPERIENCE_COMPANIES: Array<ExperienceCompany> = [
+	{ key: "kolosal", company: "Kolosal AI", url: "https://kolosal.ai" },
+	{ key: "bitwyre", company: "Bitwyre", url: "https://bitwyre.com" },
+	{ key: "skyshi-fe", company: "Skyshi Digital Indonesia", url: "https://skyshi.com" },
+	{ key: "skyshi-intern", company: "Skyshi Digital Indonesia", url: "https://skyshi.com" },
+];

--- a/src/components/home/experience.astro
+++ b/src/components/home/experience.astro
@@ -3,6 +3,7 @@ import { ArrowUpRight } from "lucide-react";
 import type { Lang } from "@/i18n/config";
 import { getDictionary } from "@/i18n/dictionary";
 import Section from "../shared/section.astro";
+import { EXPERIENCE_COMPANIES } from "./experience-companies";
 
 interface Props {
   lang: Lang;
@@ -11,26 +12,7 @@ interface Props {
 const { lang } = Astro.props;
 const t = getDictionary(lang).experience;
 
-const companies: Array<{
-  key: keyof typeof t.items;
-  company: string;
-  url: string;
-}> = [
-  { key: "kolosal", company: "Kolosal AI", url: "https://kolosal.ai" },
-  { key: "bitwyre", company: "Bitwyre", url: "https://bitwyre.com" },
-  {
-    key: "skyshi-fe",
-    company: "Skyshi Digital Indonesia",
-    url: "https://skyshi.com",
-  },
-  {
-    key: "skyshi-intern",
-    company: "Skyshi Digital Indonesia",
-    url: "https://skyshi.com",
-  },
-];
-
-const experiences = companies.map(({ key, company, url }) => ({
+const experiences = EXPERIENCE_COMPANIES.map(({ key, company, url }) => ({
   company,
   url,
   ...t.items[key],

--- a/src/lib/markdown-pages.ts
+++ b/src/lib/markdown-pages.ts
@@ -1,0 +1,99 @@
+import { EXPERIENCE_COMPANIES } from "@/components/home/experience-companies";
+import type { Lang } from "@/i18n/config";
+import { getDictionary } from "@/i18n/dictionary";
+import type { LocalizedNote } from "@/lib/notes";
+
+// Builders for the markdown variants under /md/*, served to agents via
+// `Accept: text/markdown` content negotiation in functions/_middleware.ts.
+
+const SITE = "https://rimzzlabs.com";
+
+function prefix(lang: Lang): string {
+	return lang === "en" ? "" : `/${lang}`;
+}
+
+function isoDate(value: string): string {
+	return new Date(value).toISOString().slice(0, 10);
+}
+
+function noteUrl(lang: Lang, slug: string): string {
+	return `${SITE}${prefix(lang)}/notes/${slug}`;
+}
+
+function noteLine(lang: Lang, { slug, note }: LocalizedNote): string {
+	return `- [${note.data.title}](${noteUrl(lang, slug)}) (${isoDate(note.data.publishedAt)}) — ${note.data.description}`;
+}
+
+export function markdownResponse(body: string): Response {
+	return new Response(body, { headers: { "content-type": "text/markdown; charset=utf-8" } });
+}
+
+export function buildHomeMarkdown(lang: Lang, notes: Array<LocalizedNote>): string {
+	const t = getDictionary(lang);
+	const p = prefix(lang);
+	const jobs = EXPERIENCE_COMPANIES.map(({ key, company, url }) => {
+		const item = t.experience.items[key];
+		return `- **${item.title}**, [${company}](${url}) (${item.period}) — ${item.summary}`;
+	});
+
+	return [
+		"# Rizki Citra — Software Engineer",
+		"",
+		`${t.hero.p1} ${t.hero.p2}`,
+		"",
+		`## ${t.experience.heading}`,
+		"",
+		...jobs,
+		"",
+		`## ${t.notesPage.title}`,
+		"",
+		t.notesPage.description,
+		"",
+		...notes.slice(0, 5).map((note) => noteLine(lang, note)),
+		"",
+		`All notes: ${SITE}${p}/notes`,
+		"",
+		`## ${t.nav.guestbook}`,
+		"",
+		`${t.guestbook.description} ${SITE}${p}/guestbook`,
+		"",
+		"## Machine-readable resources",
+		"",
+		"- This page, the notes index, and every note are served as markdown when the request includes `Accept: text/markdown`.",
+		`- OpenAPI description of the public API: ${SITE}/openapi.json`,
+		`- API catalog (RFC 9727): ${SITE}/.well-known/api-catalog`,
+		`- Agent skills: ${SITE}/.well-known/agent-skills/index.json`,
+		"",
+	].join("\n");
+}
+
+export function buildNotesIndexMarkdown(lang: Lang, notes: Array<LocalizedNote>): string {
+	const t = getDictionary(lang).notesPage;
+	return [
+		`# ${t.title}`,
+		"",
+		t.description,
+		"",
+		...notes.map((note) => noteLine(lang, note)),
+		"",
+	].join("\n");
+}
+
+export function buildNoteMarkdown(lang: Lang, localized: LocalizedNote): string {
+	const { slug, note, translated } = localized;
+	const t = getDictionary(lang).notesPage;
+	const lines = [
+		`# ${note.data.title}`,
+		"",
+		`> ${note.data.description}`,
+		"",
+		`- ${t.publishedOn}: ${isoDate(note.data.publishedAt)}`,
+		`- ${t.writtenBy}: Rizki Citra (${SITE})`,
+		`- Canonical: ${noteUrl(lang, slug)}`,
+	];
+	if (lang !== "en" && !translated) {
+		lines.push("", `> ${t.notTranslated}`);
+	}
+	lines.push("", "---", "", note.body ?? "");
+	return lines.join("\n");
+}

--- a/src/pages/md/id/index.md.ts
+++ b/src/pages/md/id/index.md.ts
@@ -1,0 +1,6 @@
+import { buildHomeMarkdown, markdownResponse } from "@/lib/markdown-pages";
+import { getNotes } from "@/lib/notes";
+
+export async function GET(): Promise<Response> {
+	return markdownResponse(buildHomeMarkdown("id", await getNotes("id")));
+}

--- a/src/pages/md/id/notes/[slug].md.ts
+++ b/src/pages/md/id/notes/[slug].md.ts
@@ -1,0 +1,13 @@
+import type { APIContext } from "astro";
+import { buildNoteMarkdown, markdownResponse } from "@/lib/markdown-pages";
+import { getNotes, type LocalizedNote } from "@/lib/notes";
+
+export async function getStaticPaths() {
+	const notes = await getNotes("id");
+	return notes.map((localized) => ({ params: { slug: localized.slug }, props: { localized } }));
+}
+
+export function GET(context: APIContext): Response {
+	const { localized } = context.props as { localized: LocalizedNote };
+	return markdownResponse(buildNoteMarkdown("id", localized));
+}

--- a/src/pages/md/id/notes/index.md.ts
+++ b/src/pages/md/id/notes/index.md.ts
@@ -1,0 +1,6 @@
+import { buildNotesIndexMarkdown, markdownResponse } from "@/lib/markdown-pages";
+import { getNotes } from "@/lib/notes";
+
+export async function GET(): Promise<Response> {
+	return markdownResponse(buildNotesIndexMarkdown("id", await getNotes("id")));
+}

--- a/src/pages/md/index.md.ts
+++ b/src/pages/md/index.md.ts
@@ -1,0 +1,6 @@
+import { buildHomeMarkdown, markdownResponse } from "@/lib/markdown-pages";
+import { getNotes } from "@/lib/notes";
+
+export async function GET(): Promise<Response> {
+	return markdownResponse(buildHomeMarkdown("en", await getNotes("en")));
+}

--- a/src/pages/md/notes/[slug].md.ts
+++ b/src/pages/md/notes/[slug].md.ts
@@ -1,0 +1,13 @@
+import type { APIContext } from "astro";
+import { buildNoteMarkdown, markdownResponse } from "@/lib/markdown-pages";
+import { getNotes, type LocalizedNote } from "@/lib/notes";
+
+export async function getStaticPaths() {
+	const notes = await getNotes("en");
+	return notes.map((localized) => ({ params: { slug: localized.slug }, props: { localized } }));
+}
+
+export function GET(context: APIContext): Response {
+	const { localized } = context.props as { localized: LocalizedNote };
+	return markdownResponse(buildNoteMarkdown("en", localized));
+}

--- a/src/pages/md/notes/index.md.ts
+++ b/src/pages/md/notes/index.md.ts
@@ -1,0 +1,6 @@
+import { buildNotesIndexMarkdown, markdownResponse } from "@/lib/markdown-pages";
+import { getNotes } from "@/lib/notes";
+
+export async function GET(): Promise<Response> {
+	return markdownResponse(buildNotesIndexMarkdown("en", await getNotes("en")));
+}


### PR DESCRIPTION
## Summary

Hand-rolled "Markdown for Agents" — Cloudflare's built-in zone feature needs a paid plan, so this implements the same contract in the Pages middleware: requests with `Accept: text/markdown` get a markdown version of the page, browsers keep getting HTML.

- **Build time**: Astro endpoints under `src/pages/md/` emit markdown variants mirroring the page tree — homepage, notes index, and every note, in both locales (14 files). Notes reuse the raw MDX body; homepage/notes-index are composed from the same i18n dictionaries and content collections as the HTML, so they stay in sync. The experience data moved from `experience.astro` frontmatter into `experience-companies.ts` so both renderers share it.
- **Request time**: `functions/_middleware.ts` probes `/md${path}.md` then `/md${path}/index.md` via `env.ASSETS.fetch()` and returns the hit with `Content-Type: text/markdown`, `Vary: Accept`, and an `x-markdown-tokens` estimate (matching the Cloudflare feature's headers). Pages without a variant (e.g. `/now`) fall through to HTML.
- `_headers` serves `/md/*` as `text/markdown` with `X-Robots-Tag: noindex` so direct hits work but the variants stay out of search indexes.

Implementation note: the probe deliberately uses `env.ASSETS.fetch()`, not `next(url)` — a middleware `next(url)` rewrites the in-flight request for the rest of the chain, which broke both `/notes/*` (fuzzy-router function swallowed the probe) and fallback pages (the final `next()` returned the probe's 404).

## Verification

Via `wrangler pages dev dist` with curl:
- `/`, `/id`, `/notes`, `/notes/{slug}`, `/id/notes/{slug}` + `Accept: text/markdown` → 200 `text/markdown` with `x-markdown-tokens`; id fallback notes include the not-translated notice
- Same URLs with `Accept: text/html` → HTML, unchanged
- `/now` + markdown accept → falls through to HTML (no variant)
- Fuzzy-router 404s (`/notes/jotai-state-managr`) unaffected