### PR TITLE
feat(notes): draft ts-belt note with interactive playgrounds (en+id)

### DIFF
--- a/src/components/notes/how-ts-belt-helps-me-write-predictable-code/playground-messages.tsx
+++ b/src/components/notes/how-ts-belt-helps-me-write-predictable-code/playground-messages.tsx
@@ -1,0 +1,154 @@
+import { A, D, F, O, pipe, S } from "@mobily/ts-belt";
+import { useState } from "react";
+
+import type { Lang } from "@/i18n/config";
+
+import { Playground, PlaygroundCode } from "../playground";
+
+type RawMessage = {
+	role: "system" | "user" | "assistant";
+	content: string | null;
+	created_at: number;
+	trace_id: string;
+};
+
+type StepKey = "dropSystem" | "dropEmpty" | "selectKeys" | "take";
+
+const STEPS = [
+	{ key: "dropSystem", code: 'A.reject((m) => m.role === "system")' },
+	{ key: "dropEmpty", code: "A.filterMap(toContent)" },
+	{ key: "selectKeys", code: 'A.map(D.selectKeys(["role", "content"]))' },
+	{ key: "take", code: "A.take(3)" },
+] as const satisfies ReadonlyArray<{ key: StepKey; code: string }>;
+
+type Copy = {
+	title: string;
+	hint: string;
+	stepsLabel: string;
+	result: (kept: number, total: number) => string;
+	history: Array<RawMessage>;
+};
+
+const COPY: Record<Lang, Copy> = {
+	en: {
+		title: "Playground 3 — trimming a conversation before you send it",
+		hint: "Every step is one line in a pipe. Turn them on and off to see what each one removes.",
+		stepsLabel: "Steps in the pipe",
+		result: (kept, total) => `Result — ${kept} of ${total} messages`,
+		history: [
+			{ role: "system", content: "You are a helpful assistant.", created_at: 1, trace_id: "t_01" },
+			{ role: "user", content: "What is ts-belt?", created_at: 2, trace_id: "t_02" },
+			{ role: "assistant", content: null, created_at: 3, trace_id: "t_03" },
+			{
+				role: "assistant",
+				content: "  A functional utility library.  ",
+				created_at: 4,
+				trace_id: "t_04",
+			},
+			{ role: "user", content: "   ", created_at: 5, trace_id: "t_05" },
+			{ role: "user", content: "Show me an example.", created_at: 6, trace_id: "t_06" },
+		],
+	},
+	id: {
+		title: "Playground 3 — merapikan percakapan sebelum dikirim",
+		hint: "Setiap langkah adalah satu baris di dalam pipe. Nyalakan dan matikan untuk melihat apa yang dibuang.",
+		stepsLabel: "Langkah di dalam pipe",
+		result: (kept, total) => `Hasil — ${kept} dari ${total} pesan`,
+		history: [
+			{
+				role: "system",
+				content: "Kamu adalah asisten yang membantu.",
+				created_at: 1,
+				trace_id: "t_01",
+			},
+			{ role: "user", content: "Apa itu ts-belt?", created_at: 2, trace_id: "t_02" },
+			{ role: "assistant", content: null, created_at: 3, trace_id: "t_03" },
+			{
+				role: "assistant",
+				content: "  Sebuah utility library fungsional.  ",
+				created_at: 4,
+				trace_id: "t_04",
+			},
+			{ role: "user", content: "   ", created_at: 5, trace_id: "t_05" },
+			{ role: "user", content: "Tunjukkan contohnya.", created_at: 6, trace_id: "t_06" },
+		],
+	},
+};
+
+function buildPrompt(history: Array<RawMessage>, enabled: Record<StepKey, boolean>) {
+	const withoutSystem = F.ifElse(
+		history,
+		() => enabled.dropSystem,
+		A.reject((message: RawMessage) => message.role === "system"),
+		F.identity,
+	);
+
+	const withContent = F.ifElse(
+		withoutSystem,
+		() => enabled.dropEmpty,
+		A.filterMap((message: RawMessage) =>
+			pipe(
+				O.fromNullable(message.content),
+				O.map(S.trim),
+				O.filter(S.isNotEmpty),
+				O.map((content) => ({ ...message, content })),
+			),
+		),
+		F.identity,
+	);
+
+	const narrowed = F.ifElse(
+		withContent,
+		() => enabled.selectKeys,
+		A.map((message: RawMessage) => D.selectKeys(message, ["role", "content"])),
+		F.identity,
+	);
+
+	return F.ifElse(narrowed, () => enabled.take, A.take(3), F.identity);
+}
+
+export function PlaygroundMessages(props: { lang: Lang }) {
+	const [enabled, setEnabled] = useState<Record<StepKey, boolean>>({
+		dropSystem: true,
+		dropEmpty: true,
+		selectKeys: true,
+		take: false,
+	});
+
+	function toggle(key: StepKey) {
+		setEnabled((current) => ({ ...current, [key]: !current[key] }));
+	}
+
+	const copy = COPY[props.lang];
+	const output = buildPrompt(copy.history, enabled);
+
+	return (
+		<Playground title={copy.title} hint={copy.hint}>
+			<div>
+				<p className="mb-2 text-xs font-medium text-muted-foreground">{copy.stepsLabel}</p>
+				<div className="flex flex-col gap-2">
+					{STEPS.map((step) => (
+						<button
+							key={step.key}
+							type="button"
+							data-active={enabled[step.key]}
+							aria-pressed={enabled[step.key]}
+							onClick={() => toggle(step.key)}
+							className="group/step flex items-center gap-2.5 rounded-lg border border-border bg-background px-2.5 py-2 text-left font-mono text-xs text-muted-foreground transition-colors hover:bg-muted data-[active=true]:border-transparent data-[active=true]:bg-primary data-[active=true]:text-primary-foreground"
+						>
+							<span
+								aria-hidden
+								className="size-2.5 shrink-0 rounded-full border border-current opacity-40 group-data-[active=true]/step:bg-current group-data-[active=true]/step:opacity-100"
+							/>
+							{step.code}
+						</button>
+					))}
+				</div>
+			</div>
+
+			<PlaygroundCode label={copy.result(output.length, copy.history.length)}>
+				{JSON.stringify(output, null, 2)}
+			</PlaygroundCode>
+		</Playground>
+	);
+}

--- a/src/components/notes/how-ts-belt-helps-me-write-predictable-code/playground-option.tsx
+++ b/src/components/notes/how-ts-belt-helps-me-write-predictable-code/playground-option.tsx
@@ -1,0 +1,192 @@
+import { A, G, O, pipe, S } from "@mobily/ts-belt";
+import { useState } from "react";
+
+import type { Lang } from "@/i18n/config";
+
+import { Playground, PlaygroundChoice, PlaygroundCode, PlaygroundResultRow } from "../playground";
+
+type ToolCall = { id: string; function: { name: string; arguments: string } };
+
+type ChatMessage = {
+	role: "assistant";
+	content: string | null;
+	tool_calls?: Array<ToolCall>;
+};
+
+type ChatCompletion = {
+	choices: Array<{ message?: ChatMessage; finish_reason: string }>;
+};
+
+type ScenarioKey = "text" | "toolCall" | "blank" | "noMessage" | "noChoices";
+
+function scenarios(reply: string): Record<ScenarioKey, ChatCompletion> {
+	return {
+		text: {
+			choices: [{ message: { role: "assistant", content: reply }, finish_reason: "stop" }],
+		},
+		toolCall: {
+			choices: [
+				{
+					message: {
+						role: "assistant",
+						content: null,
+						tool_calls: [
+							{ id: "call_1", function: { name: "search", arguments: '{"query":"ts-belt"}' } },
+						],
+					},
+					finish_reason: "tool_calls",
+				},
+			],
+		},
+		blank: {
+			choices: [{ message: { role: "assistant", content: "   " }, finish_reason: "stop" }],
+		},
+		noMessage: {
+			choices: [{ finish_reason: "content_filter" }],
+		},
+		noChoices: {
+			choices: [],
+		},
+	};
+}
+
+type Copy = {
+	title: string;
+	hint: string;
+	choiceLabel: string;
+	payloadLabel: string;
+	returnsLabel: string;
+	none: string;
+	stillSome: string;
+	reply: string;
+	options: ReadonlyArray<{ value: ScenarioKey; label: string }>;
+};
+
+const COPY: Record<Lang, Copy> = {
+	en: {
+		title: "Playground 1 — what the model actually returns",
+		hint: "Pick a response shape. All three functions below run the real ts-belt build in your browser.",
+		choiceLabel: "Response from the API",
+		payloadLabel: "The payload",
+		returnsLabel: "Returns",
+		none: "undefined  (None)",
+		stillSome: "null  (still Some!)",
+		reply: "  ts-belt is a utility library.  ",
+		options: [
+			{ value: "text", label: "Text reply" },
+			{ value: "toolCall", label: "Tool call (content: null)" },
+			{ value: "blank", label: "Whitespace only" },
+			{ value: "noMessage", label: "No message" },
+			{ value: "noChoices", label: "No choices" },
+		],
+	},
+	id: {
+		title: "Playground 1 — apa yang sebenarnya dikembalikan model",
+		hint: "Pilih bentuk responsnya. Ketiga fungsi di bawah menjalankan ts-belt yang asli di browser kamu.",
+		choiceLabel: "Respons dari API",
+		payloadLabel: "Isi payload-nya",
+		returnsLabel: "Menghasilkan",
+		none: "undefined  (None)",
+		stillSome: "null  (masih dianggap Some!)",
+		reply: "  ts-belt adalah utility library.  ",
+		options: [
+			{ value: "text", label: "Balasan teks" },
+			{ value: "toolCall", label: "Tool call (content: null)" },
+			{ value: "blank", label: "Hanya spasi" },
+			{ value: "noMessage", label: "Tanpa message" },
+			{ value: "noChoices", label: "Tanpa choices" },
+		],
+	},
+};
+
+function withOptionalChaining(completion: ChatCompletion) {
+	return completion.choices[0]?.message?.content?.trim();
+}
+
+function withoutFromNullable(completion: ChatCompletion) {
+	return pipe(
+		completion.choices,
+		A.head,
+		O.flatMap((choice) => choice.message),
+		O.flatMap((message) => message.content),
+		O.map(S.trim),
+		O.filter(S.isNotEmpty),
+	);
+}
+
+function withFromNullable(completion: ChatCompletion) {
+	return pipe(
+		completion.choices,
+		A.head,
+		O.flatMap((choice) => O.fromNullable(choice.message)),
+		O.flatMap((message) => O.fromNullable(message.content)),
+		O.map(S.trim),
+		O.filter(S.isNotEmpty),
+	);
+}
+
+function toMessage(error: unknown) {
+	if (G.isError(error)) return error.message;
+
+	return String(error);
+}
+
+function runSafely(copy: Copy, fn: () => unknown) {
+	try {
+		const value = fn();
+
+		if (value === undefined) return { output: copy.none, tone: "muted" as const };
+		if (value === null) return { output: copy.stillSome, tone: "error" as const };
+
+		return { output: JSON.stringify(value), tone: "ok" as const };
+	} catch (error) {
+		return { output: `TypeError: ${toMessage(error)}`, tone: "error" as const };
+	}
+}
+
+export function PlaygroundOption(props: { lang: Lang }) {
+	const [scenario, setScenario] = useState<ScenarioKey>("text");
+
+	const copy = COPY[props.lang];
+	const completion = scenarios(copy.reply)[scenario];
+
+	const chained = runSafely(copy, () => withOptionalChaining(completion));
+	const trap = runSafely(copy, () => withoutFromNullable(completion));
+	const safe = runSafely(copy, () => withFromNullable(completion));
+
+	return (
+		<Playground title={copy.title} hint={copy.hint}>
+			<PlaygroundChoice
+				label={copy.choiceLabel}
+				options={copy.options}
+				value={scenario}
+				onSelect={setScenario}
+			/>
+
+			<PlaygroundCode label={copy.payloadLabel}>
+				{JSON.stringify(completion, null, 2)}
+			</PlaygroundCode>
+
+			<div className="space-y-3">
+				<PlaygroundResultRow
+					label={copy.returnsLabel}
+					tone={chained.tone}
+					code="choices[0]?.message?.content?.trim()"
+					output={chained.output}
+				/>
+				<PlaygroundResultRow
+					label={copy.returnsLabel}
+					tone={trap.tone}
+					code="O.flatMap((message) => message.content)"
+					output={trap.output}
+				/>
+				<PlaygroundResultRow
+					label={copy.returnsLabel}
+					tone={safe.tone}
+					code="O.flatMap((message) => O.fromNullable(message.content))"
+					output={safe.output}
+				/>
+			</div>
+		</Playground>
+	);
+}

--- a/src/components/notes/how-ts-belt-helps-me-write-predictable-code/playground-result.tsx
+++ b/src/components/notes/how-ts-belt-helps-me-write-predictable-code/playground-result.tsx
@@ -1,0 +1,186 @@
+import { F, pipe, R } from "@mobily/ts-belt";
+import { useState } from "react";
+import { z } from "zod";
+
+import type { Lang } from "@/i18n/config";
+
+import { Playground, PlaygroundChoice, PlaygroundResultRow } from "../playground";
+
+const searchArgsSchema = z.object({
+	query: z.string(),
+	limit: z.number().default(10),
+});
+
+type PresetKey = "valid" | "noLimit" | "noQuery" | "badLimit" | "malformed";
+
+const PRESETS: Record<PresetKey, string> = {
+	valid: '{ "query": "ts-belt", "limit": 5 }',
+	noLimit: '{ "query": "ts-belt" }',
+	noQuery: '{ "limit": 5 }',
+	badLimit: '{ "query": "ts-belt", "limit": "five" }',
+	malformed: '{ "query": "ts-belt", ',
+};
+
+type Copy = {
+	title: string;
+	hint: string;
+	editLabel: string;
+	step1: string;
+	step2: string;
+	step3: string;
+	skipped: string;
+	success: (query: string, limit: number) => string;
+	failure: (message: string) => string;
+	options: ReadonlyArray<{ value: PresetKey; label: string }>;
+};
+
+const COPY: Record<Lang, Copy> = {
+	en: {
+		title: "Playground 2 — parsing what the model asked for",
+		hint: "Tool arguments arrive as a raw string. Edit it, or pick a preset, and watch where the pipeline stops.",
+		editLabel: "Edit the arguments",
+		step1: "Step 1",
+		step2: "Step 2",
+		step3: "What the user sees",
+		skipped: "skipped, the error passed straight through",
+		success: (query, limit) => `Searching for "${query}", ${limit} results`,
+		failure: (message) => `Could not run the tool: ${message}`,
+		options: [
+			{ value: "valid", label: "Valid" },
+			{ value: "noLimit", label: "No limit, so it defaults" },
+			{ value: "noQuery", label: "No query" },
+			{ value: "badLimit", label: "Limit is a string" },
+			{ value: "malformed", label: "Malformed JSON" },
+		],
+	},
+	id: {
+		title: "Playground 2 — membaca permintaan dari model",
+		hint: "Argumen tool datang sebagai string mentah. Ubah isinya, atau pilih preset, lalu lihat di mana pipeline-nya berhenti.",
+		editLabel: "Ubah argumennya",
+		step1: "Langkah 1",
+		step2: "Langkah 2",
+		step3: "Yang dilihat pengguna",
+		skipped: "dilewati, error-nya diteruskan langsung ke bawah",
+		success: (query, limit) => `Mencari "${query}", ${limit} hasil`,
+		failure: (message) => `Tidak bisa menjalankan tool: ${message}`,
+		options: [
+			{ value: "valid", label: "Valid" },
+			{ value: "noLimit", label: "Tanpa limit, jadi memakai default" },
+			{ value: "noQuery", label: "Tanpa query" },
+			{ value: "badLimit", label: "Limit berupa string" },
+			{ value: "malformed", label: "JSON rusak" },
+		],
+	},
+};
+
+function parseArguments(raw: string): R.Result<unknown, Error> {
+	return R.fromExecution(() => JSON.parse(raw) as unknown);
+}
+
+function toSearchArgs(value: unknown) {
+	return R.fromExecution(() => searchArgsSchema.parse(value));
+}
+
+type StepView = { output: string; tone: "ok" | "error" | "muted" };
+
+function toMessage(error: Error) {
+	return F.ifElse(
+		error,
+		(value) => value instanceof z.ZodError,
+		(value) => z.prettifyError(value as z.ZodError),
+		(value) => value.message,
+	);
+}
+
+function describe(result: R.Result<unknown, Error>) {
+	return R.match(
+		result,
+		(value): StepView => ({ output: `Ok(${JSON.stringify(value)})`, tone: "ok" }),
+		(error): StepView => ({ output: `Error(${toMessage(error)})`, tone: "error" }),
+	);
+}
+
+export function PlaygroundResult(props: { lang: Lang }) {
+	const [preset, setPreset] = useState<PresetKey>("valid");
+	const [raw, setRaw] = useState(PRESETS.valid);
+
+	function handlePreset(next: PresetKey) {
+		setPreset(next);
+		setRaw(PRESETS[next]);
+	}
+
+	const copy = COPY[props.lang];
+	const parsed = parseArguments(raw);
+	const validated = pipe(parsed, R.flatMap(toSearchArgs));
+
+	const parsedView = describe(parsed);
+	const validatedView = R.match(
+		parsed,
+		(): StepView => describe(validated),
+		(): StepView => ({
+			output: copy.skipped,
+			tone: "muted",
+		}),
+	);
+
+	const final = R.match(
+		validated,
+		(args) => copy.success(args.query, args.limit),
+		(error) => copy.failure(toMessage(error)),
+	);
+
+	const finalTone = R.match(
+		validated,
+		(): StepView["tone"] => "ok",
+		(): StepView["tone"] => "error",
+	);
+
+	return (
+		<Playground title={copy.title} hint={copy.hint}>
+			<PlaygroundChoice
+				label="tool_call.function.arguments"
+				options={copy.options}
+				value={preset}
+				onSelect={handlePreset}
+			/>
+
+			<div>
+				<label
+					htmlFor="playground-arguments"
+					className="mb-2 block text-xs font-medium text-muted-foreground"
+				>
+					{copy.editLabel}
+				</label>
+				<textarea
+					id="playground-arguments"
+					value={raw}
+					spellCheck={false}
+					onChange={(event) => setRaw(event.target.value)}
+					rows={3}
+					className="w-full resize-y rounded-lg border border-border bg-muted/40 p-3 font-mono text-xs outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+				/>
+			</div>
+
+			<div className="space-y-3">
+				<PlaygroundResultRow
+					label={copy.step1}
+					tone={parsedView.tone}
+					code="R.fromExecution(() => JSON.parse(raw))"
+					output={parsedView.output}
+				/>
+				<PlaygroundResultRow
+					label={copy.step2}
+					tone={validatedView.tone}
+					code="R.flatMap(toSearchArgs)  // zod schema.parse"
+					output={validatedView.output}
+				/>
+				<PlaygroundResultRow
+					label={copy.step3}
+					tone={finalTone}
+					code="R.match(validated, onOk, onError)"
+					output={final}
+				/>
+			</div>
+		</Playground>
+	);
+}

--- a/src/components/notes/playground.tsx
+++ b/src/components/notes/playground.tsx
@@ -1,0 +1,100 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface PlaygroundProps {
+	title: string;
+	hint: string;
+	children: ReactNode;
+}
+
+export function Playground(props: PlaygroundProps) {
+	return (
+		<div className="not-prose my-8 overflow-hidden rounded-xl border border-border bg-card text-card-foreground">
+			<div className="border-b border-border bg-muted/40 px-4 py-3">
+				<p className="text-sm font-semibold">{props.title}</p>
+				<p className="mt-1 text-xs leading-relaxed text-muted-foreground">{props.hint}</p>
+			</div>
+			<div className="space-y-4 p-4">{props.children}</div>
+		</div>
+	);
+}
+
+interface PlaygroundChoiceProps<T extends string> {
+	label: string;
+	options: ReadonlyArray<{ value: T; label: string }>;
+	value: T;
+	onSelect: (value: T) => void;
+}
+
+export function PlaygroundChoice<T extends string>(props: PlaygroundChoiceProps<T>) {
+	return (
+		<div>
+			<p className="mb-2 text-xs font-medium text-muted-foreground">{props.label}</p>
+			<div className="flex flex-wrap gap-2">
+				{props.options.map((option) => (
+					<button
+						key={option.value}
+						type="button"
+						data-active={props.value === option.value}
+						aria-pressed={props.value === option.value}
+						onClick={() => props.onSelect(option.value)}
+						className="rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground data-[active=true]:border-transparent data-[active=true]:bg-primary data-[active=true]:text-primary-foreground"
+					>
+						{option.label}
+					</button>
+				))}
+			</div>
+		</div>
+	);
+}
+
+interface PlaygroundCodeProps {
+	label: string;
+	children: string;
+}
+
+export function PlaygroundCode(props: PlaygroundCodeProps) {
+	return (
+		<div>
+			<p className="mb-2 text-xs font-medium text-muted-foreground">{props.label}</p>
+			<pre className="overflow-x-auto rounded-lg border border-border bg-muted/40 p-3 font-mono text-xs leading-relaxed">
+				{props.children}
+			</pre>
+		</div>
+	);
+}
+
+interface PlaygroundResultRowProps {
+	label: string;
+	code: string;
+	output: string;
+	tone: "ok" | "error" | "muted";
+}
+
+const TONE_CLASS: Record<PlaygroundResultRowProps["tone"], string> = {
+	ok: "border-emerald-500/40 bg-emerald-500/5 text-emerald-700 dark:text-emerald-400",
+	error: "border-destructive/40 bg-destructive/5 text-destructive",
+	muted: "border-border bg-muted/40 text-muted-foreground",
+};
+
+export function PlaygroundResultRow(props: PlaygroundResultRowProps) {
+	return (
+		<div className="rounded-lg border border-border">
+			<p className="border-b border-border px-3 py-2 font-mono text-[11px] leading-relaxed wrap-break-word">
+				{props.code}
+			</p>
+			<div className="flex flex-col gap-1 px-3 py-2">
+				<span className="text-[11px] font-medium text-muted-foreground">{props.label}</span>
+				<span
+					className={cn(
+						"rounded-md border px-2 py-1 font-mono text-xs wrap-break-word",
+						TONE_CLASS[props.tone],
+					)}
+				>
+					{props.output}
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/src/content/notes/en/how-ts-belt-helps-me-write-predictable-code.mdx
+++ b/src/content/notes/en/how-ts-belt-helps-me-write-predictable-code.mdx
@@ -1,0 +1,588 @@
+---
+title: "How ts-belt Helps Me Write Predictable Code"
+description: "ts-belt is a TypeScript utility library created by Mobily that uses a functional approach. Here is how Option, Result, and AsyncResult replaced the pile of null checks and try/catch in the LLM code I work on every day."
+publishedAt: "08/09/2026"
+status: "draft"
+featured: false
+author: rimzzlabs
+keywords:
+  - TS-Belt
+  - Functional Programming Frontend
+  - Option
+  - Result
+  - LLM Frontend
+---
+
+import { PlaygroundOption } from "@/components/notes/how-ts-belt-helps-me-write-predictable-code/playground-option";
+import { PlaygroundResult } from "@/components/notes/how-ts-belt-helps-me-write-predictable-code/playground-result";
+import { PlaygroundMessages } from "@/components/notes/how-ts-belt-helps-me-write-predictable-code/playground-messages";
+
+The first time our chat UI went blank, I blamed the backend.
+
+What actually happened is that the model called a tool instead of writing a reply. I had just rewritten the message parsing with ts-belt, the whole thing type checked, and it still threw a `TypeError` in production.
+
+One field did it. `content` comes back as `null` when the model returns tool calls, and my pipeline treated that `null` as a perfectly good value before handing it to `.trim()`.
+
+This note is about the parts of ts-belt that made that whole class of bug go away for me. It's also about the one gap that lets you write the exact same bug again without noticing.
+
+## Introduction
+
+[ts-belt](https://mobily.github.io/ts-belt/) is a TypeScript utility library created by [Marcin Dziewulski](https://github.com/mobily), it uses a functional programming approach and is the [fastest utility library](https://mobily.github.io/ts-belt/benchmarks/introduction) out there.
+
+```sh
+npm install @mobily/ts-belt
+```
+
+Everything ships as small namespaces you import by letter:
+
+- `A` for arrays, `D` for plain objects, `S` for strings, `N` for numbers, `B` for booleans.
+- `F` for function helpers, `G` for type guards.
+- `O` for `Option`, `R` for `Result`, and `AR` for `AsyncResult`.
+- `pipe` and `flow` to glue them together.
+
+[Lodash](https://github.com/lodash/lodash) already covers that first line well enough. What pulled me in was the rest.
+
+> Every snippet here runs on `4.0.0-rc.5`. The `AR` module is new in v4, so on v3 you'll have everything except the async part.
+
+## Reading a Transformation Top to Bottom
+
+Almost every snippet after this runs through `pipe`. It only works because of one design choice ts-belt repeats in nearly every function, so let's get that out of the way first.
+
+Nearly every function in ts-belt has two signatures. Pass the data first and it runs right away. Leave the data out and you get back a function that's still waiting for it.
+
+```ts
+import { A } from "@mobily/ts-belt";
+
+const roles = A.map(messages, (message) => message.role);
+
+const getRoles = A.map((message: ChatMessage) => message.role);
+```
+
+That second form exists so functions can queue up inside `pipe`, which takes a value and hands it down the list.
+
+```ts
+import { A, S, pipe } from "@mobily/ts-belt";
+
+const roles = pipe(
+  messages,
+  A.map((message) => message.role),
+  A.reject(S.isEmpty),
+  A.uniq,
+);
+```
+
+TypeScript infers the type at every step, so `A.reject` already knows it's looking at strings. No wrapper object, no class to learn, just functions passing values along.
+
+`flow` is the same idea without the value, so you get a reusable function instead of a result. `pipe` caps out at nine functions, and past that you split it in two.
+
+## All the Ways an Answer Can Be Missing
+
+The `O` module is ts-belt's answer to values that might not be there. To see why that matters, look at what a chat completion actually hands you:
+
+```ts
+type ToolCall = {
+  id: string;
+  function: { name: string; arguments: string };
+};
+
+type ChatMessage = {
+  role: "assistant";
+  content: string | null;
+  tool_calls?: Array<ToolCall>;
+};
+
+type ChatCompletion = {
+  choices: Array<{ message?: ChatMessage; finish_reason: string }>;
+};
+```
+
+Count how many ways that response can come back with nothing in it.
+
+`choices` can be empty. `message` can be missing when a content filter fires. `content` is `null` on every tool call. And when the model does answer, it sometimes answers with whitespace.
+
+So pulling out the reply text ends up like this:
+
+```ts
+const FALLBACK = "The model did not return any text.";
+
+function getReplyText(completion: ChatCompletion) {
+  if (completion.choices.length === 0) return FALLBACK;
+
+  const message = completion.choices[0].message;
+  if (!message) return FALLBACK;
+
+  if (message.content === null) return FALLBACK;
+
+  const text = message.content.trim();
+  if (text === "") return FALLBACK;
+
+  return text;
+}
+```
+
+Four guards, four early returns, the same fallback typed out four times.
+
+Nothing is wrong with it. I wrote this exact shape for years. But the actual job is "read the reply", and that job is buried under the work of proving it's safe to do.
+
+`Option` is where those four kinds of nothing become one. In most languages it's a box you have to open. In ts-belt it isn't a box at all:
+
+```ts
+import type { O } from "@mobily/ts-belt";
+
+type ReplyText = O.Option<string>; // string | null | undefined
+```
+
+That's the whole thing. `O.Option<A>` is defined as `A | null | undefined`, nothing more.
+
+Nothing gets allocated and nothing gets wrapped, which matters more than it sounds. You can adopt `O` in one function without converting anything around it, and the result goes straight back into React or any function that already takes `string | undefined`.
+
+Every ts-belt function that might come up empty returns one:
+
+```ts
+import { A, D, S } from "@mobily/ts-belt";
+
+A.head(completion.choices); // Option<Choice>
+A.getBy(toolCalls, (call) => call.id === id); // Option<ToolCall>
+D.get(headers, "x-request-id"); // Option<string>
+S.search(reply, /\d+/); // Option<number>
+```
+
+Now the same function, rewritten:
+
+```ts
+import { A, O, S, pipe } from "@mobily/ts-belt";
+
+function getReplyText(completion: ChatCompletion) {
+  const text = pipe(
+    completion.choices,
+    A.head,
+    O.flatMap((choice) => O.fromNullable(choice.message)),
+    O.flatMap((message) => O.fromNullable(message.content)),
+    O.map(S.trim),
+    O.filter(S.isNotEmpty),
+  );
+
+  return O.getWithDefault(text, FALLBACK);
+}
+```
+
+The guards are gone and the fallback shows up once, at the end.
+
+What makes it work is that `O.map`, `O.flatMap`, and `O.filter` all follow one rule. If the value is there, run the function. If it isn't, skip it and pass the nothing along.
+
+So the empty `choices` case never needs its own `if`. `A.head` returns nothing, and every step after it quietly does nothing too.
+
+At the edge of a component, `O.match` is how you get back out and handle both sides on purpose:
+
+```tsx
+import { O } from "@mobily/ts-belt";
+
+function ReplyBubble(props: { text: O.Option<string> }) {
+  return O.match(
+    props.text,
+    (text) => <p className="reply">{text}</p>,
+    () => <p className="reply-empty">{FALLBACK}</p>,
+  );
+}
+```
+
+### The `null` That Slips Through
+
+Now the part that cost me an afternoon.
+
+The type says `Option<A> = A | null | undefined`. The runtime disagrees. Inside ts-belt, the check for nothing is this:
+
+```ts
+function isNone(x) {
+  return x === void 0;
+}
+```
+
+Only `undefined` counts. A `null` gets treated as a real value and passed to the next function like any other.
+
+Which means this version type checks without a single complaint, then crashes the moment the model calls a tool:
+
+```ts
+import { A, O, S, pipe } from "@mobily/ts-belt";
+
+pipe(
+  completion.choices,
+  A.head,
+  O.flatMap((choice) => choice.message),
+  O.flatMap((message) => message.content),
+  O.map(S.trim),
+);
+```
+
+`message.content` is `string | null`, which TypeScript happily accepts as an `Option<string>`. But when it's `null`, `O.map` decides it's `Some`, calls `S.trim(null)`, and there's your `TypeError`.
+
+It's a box labelled empty that still has something in it, and the label is the only thing anyone checks.
+
+Try it below. Switch to the tool call and watch the middle row fall over:
+
+<PlaygroundOption client:visible lang="en" />
+
+The fix is one function. `O.fromNullable` turns `null` into `undefined`:
+
+```ts
+import { O } from "@mobily/ts-belt";
+
+O.flatMap((message) => O.fromNullable(message.content));
+```
+
+The habit I ended up with: anything from outside my own pipeline goes through `O.fromNullable` first. API responses, `JSON.parse`, form values, third party libraries. Values ts-belt produced itself, like whatever `A.head` gave back, are already clean.
+
+Small rule, but it's the whole difference between `Option` being predictable and `Option` being a trap.
+
+## Checking Data You Did Not Create
+
+Anything a model hands back starts life as `unknown`. `G` is the module that tells you what a value actually is, and it's worth meeting before `Result`.
+
+These guards narrow properly when you call them directly, so TypeScript follows along:
+
+```ts
+import { G } from "@mobily/ts-belt";
+
+G.isString(value);
+G.isNumber(value);
+G.isObject(value);
+G.isNotNullable(value);
+```
+
+The one I reach for most is `G.isNotNullable`, because it cleans up a list and narrows the type in the same step:
+
+```ts
+import { A, G, pipe } from "@mobily/ts-belt";
+
+const usages = pipe(
+  completions,
+  A.map((completion) => completion.usage), // Array<Option<Usage>>
+  A.filter(G.isNotNullable), // Array<Usage>
+);
+```
+
+No cast, no `as`, and the array that comes out is genuinely free of holes.
+
+## Getting Ternaries Out of Your Pipelines
+
+`F` is the module I ignored for the longest time, and it's the one that finally got the ternaries out of my pipelines.
+
+A ternary is fine on its own. The problem is it can't sit inside a `pipe`, so the moment you need one you're back to pulling the value out into a variable and breaking the chain.
+
+`F.ifElse` takes the value, a predicate, and the two branches:
+
+```ts
+import { F } from "@mobily/ts-belt";
+
+const model = F.ifElse(
+  request,
+  (value) => value.premium,
+  F.always("opus"),
+  F.always("haiku"),
+);
+```
+
+`F.always` builds a function that ignores its input and returns a constant, which is what those branches want.
+
+For the much more common "use this unless it's missing", there's `F.defaultTo`:
+
+```ts
+import { F } from "@mobily/ts-belt";
+
+const temperature = F.defaultTo(request.temperature, 0.7);
+```
+
+It keys off nullability rather than truthiness, so a `0` stays a `0`. That's the bug `||` gives you and `??` fixed, except this one composes.
+
+`F.identity` is the other one worth knowing. It returns its input untouched, which is exactly what you want for the "leave it alone" branch of an `F.ifElse`.
+
+## Putting the Failure in the Return Type
+
+`Option` answers "is it there?". It can't tell you _why_ something is missing, and it can't carry a message to the user. That's `Result`.
+
+Take an ordinary signature:
+
+```ts
+function parseArguments(raw: string): SearchArgs;
+```
+
+It promises arguments. It might also throw, and the type says nothing about it. Whether you need a `try/catch` is something you find out by reading the body, and the body of everything it calls.
+
+Every `try/catch` we write is an admission that a type lied to us.
+
+`Result` puts the failure in the return type where the compiler can see it:
+
+```ts
+import type { R } from "@mobily/ts-belt";
+
+type ParsedArgs = R.Result<SearchArgs, Error>; // Ok<SearchArgs> | Error<Error>
+```
+
+Unlike `Option`, this one really is a wrapper. It's a small tagged object holding either the value or the error, and you can't read the value without deciding what happens when there isn't one.
+
+Getting one out of code that throws takes a single function:
+
+```ts
+import { R } from "@mobily/ts-belt";
+
+const parsed = R.fromExecution(() => JSON.parse(raw) as unknown);
+const answer = await R.fromPromise(callModel(prompt));
+```
+
+`R.fromExecution` handles anything synchronous, `R.fromPromise` handles promises, and both hand back a `Result` whose error side is a real `Error`.
+
+### Stacking Steps That Can Fail
+
+The payoff shows up when several steps can fail in a row.
+
+When the model calls a tool, the arguments arrive as a raw string. It has to be parsed, and then it has to be checked, because nothing guarantees the model filled in the fields we asked for.
+
+My first attempt at the checking half was a ladder of `G` guards with an early return on each one. It worked, but it was the only imperative thing left in the file, and it bothered me enough to try rewriting it as a `pipe`.
+
+That's when I found the wall.
+
+```ts
+import { G, R, pipe } from "@mobily/ts-belt";
+
+pipe(
+  R.fromPredicate(value, G.isObject, new Error("not an object")),
+  R.map((object) => object.query),
+);
+```
+
+This doesn't compile, and the reason is worth knowing. `R.fromPredicate` here gives you `Result<{}, Error>`. The guard ran, but the narrowing didn't survive the trip.
+
+`A.filter` is the exception. It ships a dedicated overload that carries a type predicate through, which is exactly why `A.filter(G.isNotNullable)` narrowed the array earlier. `O.filter` and `R.fromPredicate` have no such overload, so anything they touch comes out as wide as it went in.
+
+So `G` is for narrowing a value you already hold. It can't turn `unknown` into a shape. For that you want a schema, and I already have [zod](https://zod.dev) in this project:
+
+```ts
+import { R } from "@mobily/ts-belt";
+import { z } from "zod";
+
+const searchArgsSchema = z.object({
+  query: z.string(),
+  limit: z.number().default(10),
+});
+
+type SearchArgs = z.infer<typeof searchArgsSchema>;
+
+function parseArguments(raw: string): R.Result<unknown, Error> {
+  return R.fromExecution(() => JSON.parse(raw) as unknown);
+}
+
+function toSearchArgs(value: unknown) {
+  return R.fromExecution(() => searchArgsSchema.parse(value));
+}
+```
+
+The ladder is gone. `searchArgsSchema.parse` throws on a bad shape, `R.fromExecution` catches it, and what comes back is a properly typed `Result<SearchArgs, Error>`. The default for `limit` moved into the schema, where it reads better anyway.
+
+This is the division of labour I've settled on. zod decides what the data _is_. ts-belt decides how the steps _flow_.
+
+And now both halves are one step each, so they join up:
+
+```ts
+import { R, pipe } from "@mobily/ts-belt";
+
+function readSearchArgs(toolCall: ToolCall) {
+  return pipe(
+    parseArguments(toolCall.function.arguments),
+    R.flatMap(toSearchArgs),
+    R.mapError((error) => error.message),
+  );
+}
+```
+
+`R.flatMap` follows the same rule `O.flatMap` does. If what comes in is an `Ok`, run the next step. If it's already an `Error`, skip the step entirely and pass the error down untouched.
+
+Think of a document going through a row of service counters. Counter one parses it, counter two checks it, counter three runs the search. The moment one counter rejects it, it gets a rejection slip and heads straight for the exit. Nobody downstream opens the folder, and no counter needs a "was this already rejected?" check at the top of the desk.
+
+That check is exactly what a `try/catch` around every step would be.
+
+`R.mapError` on the last line is worth its own sentence. Inside the pipeline the error is a real `Error`, which is what you want in a log. The component only needs a string. `R.mapError` translates one to the other and never touches the success path.
+
+One caveat now that zod is in the chain. A `ZodError` stores its `message` as a JSON dump of every issue, which is unreadable in a toast. `z.prettifyError` is the one to reach for there.
+
+Break the JSON below and watch step two get skipped:
+
+<PlaygroundResult client:visible lang="en" />
+
+### Opening It Where the User Sees It
+
+A `Result` shouldn't travel far. I keep it inside the module that made it and open it where the outcome gets rendered:
+
+```tsx
+import { R } from "@mobily/ts-belt";
+
+function ToolCallStatus(props: { result: R.Result<SearchArgs, string> }) {
+  return R.match(
+    props.result,
+    (args) => <p>Searching for {args.query}</p>,
+    (message) => <p role="alert">{message}</p>,
+  );
+}
+```
+
+`R.match` forces both branches to exist. You can't render the happy path and quietly forget the other one, which is a thing I've shipped more than once with a plain `try/catch`.
+
+## When Half the Steps Are Promises
+
+Here's the problem with everything above: in agent code, almost nothing is synchronous.
+
+The model call is a promise. The tool is a promise. Between them sits parsing, which isn't. So you end up with an `await`, then a `Result`, then another `await`, and the pipeline you were building falls apart into a pile of intermediate variables.
+
+`AsyncResult` is v4's answer, and the definition is refreshingly boring:
+
+```ts
+import type { AR } from "@mobily/ts-belt";
+
+type Turn = AR.AsyncResult<Array<string>, Error>; // Promise<Result<Array<string>, Error>>
+```
+
+An `AsyncResult<A, B>` is a `Promise<Result<A, B>>`, with the same combinators you already know. `AR.fold` takes a step that returns a plain `Result`, `AR.flatMap` takes one that returns another `AsyncResult`, and `AR.match` unwraps the whole thing at the end.
+
+Which means one agent turn, from prompt to rendered answer, becomes a single expression:
+
+```ts
+import { AR, pipe } from "@mobily/ts-belt";
+
+function runTurn(prompt: string) {
+  return pipe(
+    AR.make(callModel(prompt)),
+    AR.fold(firstToolCall),
+    AR.fold((toolCall) => parseArguments(toolCall.function.arguments)),
+    AR.fold(toSearchArgs),
+    AR.flatMap((args) => AR.make(runSearch(args))),
+    AR.match(
+      (results) => `Found ${results.length} results`,
+      (error) => `Turn failed: ${error.message}`,
+    ),
+  );
+}
+```
+
+Five things can fail in there. The model can rate limit, it can decline to call a tool, the arguments can be malformed, they can be the wrong shape, and the search itself can go down.
+
+There isn't one `try` in the whole function, and every one of those failures lands in the same place with a message attached.
+
+`AR.make` is what lifts a normal promise in, and it catches rejections for you, so a thrown `429` arrives as an `Error` instead of blowing up the chain.
+
+The step that finds the tool call is just `Option` work handed over to `Result`:
+
+```ts
+import { A, O, R, pipe } from "@mobily/ts-belt";
+
+function firstToolCall(completion: ChatCompletion): R.Result<ToolCall, Error> {
+  const toolCall = pipe(
+    completion.choices,
+    A.head,
+    O.flatMap((choice) => O.fromNullable(choice.message)),
+    O.flatMap((message) => O.fromNullable(message.tool_calls)),
+    O.flatMap(A.head),
+  );
+
+  return R.fromNullable(toolCall, new Error("The model did not call a tool"));
+}
+```
+
+`R.fromNullable` is the bridge. `Option` gets you as far as "there's nothing here", then you attach a reason and hand it to `Result`.
+
+## Reshaping the Data Before It Goes Out
+
+`A` for arrays and `D` for plain objects are the unglamorous half of the library, and probably the half I use most.
+
+Before a prompt goes out, the history needs work. Drop the system message, drop the turns where the model only called a tool, trim the whitespace, strip the internal columns, and cut it to something that fits the context window.
+
+That's five things, and it's five lines:
+
+```ts
+import { A, D, O, S, pipe } from "@mobily/ts-belt";
+
+function toPromptMessages(messages: Array<StoredMessage>) {
+  return pipe(
+    messages,
+    A.reject((message) => message.role === "system"),
+    A.filterMap((message) =>
+      pipe(
+        O.fromNullable(message.content),
+        O.map(S.trim),
+        O.filter(S.isNotEmpty),
+        O.map((content) =>
+          D.merge(D.selectKeys(message, ["role"]), { content }),
+        ),
+      ),
+    ),
+    A.take(20),
+  );
+}
+```
+
+`A.filterMap` is the one worth knowing. It maps and filters in the same pass, and it decides which is which by whether your function came back with a value or with nothing.
+
+`D.selectKeys` picks the fields the API actually wants, so `created_at` and `trace_id` stay out of the payload.
+
+Toggle the steps and watch what each one takes out:
+
+<PlaygroundMessages client:visible lang="en" />
+
+Counting tokens across a session is the same shape:
+
+```ts
+import { A, G, N, pipe } from "@mobily/ts-belt";
+
+function totalTokens(completions: Array<ChatCompletion>) {
+  return pipe(
+    completions,
+    A.map((completion) => completion.usage),
+    A.filter(G.isNotNullable),
+    A.reduce(0, (sum, usage) =>
+      N.add(sum, usage.prompt_tokens + usage.completion_tokens),
+    ),
+  );
+}
+```
+
+## What It Costs You
+
+I'd rather write this section than have you find these out on a Friday.
+
+**`null` isn't `None` at runtime.** The one from earlier, and the only one here that can actually crash. `O.fromNullable` at every boundary.
+
+**Arrays come back `readonly`.** `A.map` returns `readonly T[]`, so assigning it to `Array<string>` won't compile. Usually you just type your own signatures as `ReadonlyArray<T>` and move on. If that's too much churn, there's a global escape hatch you declare once, and it needs `skipLibCheck: true`:
+
+```ts
+declare global {
+  namespace Belt {
+    type UseMutableArrays = 1;
+  }
+}
+
+export {};
+```
+
+**Both `match` branches have to agree on their return type.** The generic gets pinned by whichever callback comes first, so when the second one returns a slightly different shape the error points at the wrong place. Annotate the return type and it goes away.
+
+**`R.Error` isn't a JavaScript `Error`.** It's a container that'll hold anything, including a plain string. That's the point, typed error values are useful, but `throw`ing one gives you a genuinely baffling stack trace.
+
+**`Option` can't nest.** `Option<Option<string>>` collapses, because it's a union and not a box. So `D.get(config, "model")` can't tell you the difference between "the key is missing" and "the key is there and holds `undefined`". If that matters, use `Result`.
+
+**And the cost that isn't technical.** A `pipe` of six functions only reads better if the reader knows what `flatMap` does. On a team that's never seen this style it isn't clearer, it's just unfamiliar. I bring it in where the payoff is obvious, which for me is anything touching the network or reshaping data, and I leave plain `if` statements alone where they're already the clearest thing on the page.
+
+## Closing Thoughts
+
+`if` statements were never the problem.
+
+The problem is that a defensive `if` looks exactly like a business rule. A few months in, nobody can tell which branches encode something real and which ones only exist to keep TypeScript quiet.
+
+What stuck for me:
+
+1. Reach for `Option` when the only question is "is it there?", and `Result` when you also owe someone a reason.
+2. Run anything from outside your pipeline through `O.fromNullable` before another `O` function touches it.
+3. Wrap throwing code once with `R.fromExecution` or `R.fromPromise`, then chain with `R.flatMap` instead of nesting `try/catch`.
+4. When the steps are a mix of sync and async, reach for `AR` instead of unwrapping between every `await`.
+5. Keep `Result` inside the module that made it and open it with `R.match` at the component boundary, so both branches have to exist.
+
+None of this makes the failure cases go away. It moves them into the type signature where the compiler can point at them, instead of leaving them in a function body where only a careful reader will notice.
+
+The [ts-belt docs](https://mobily.github.io/ts-belt/) are short and worth reading end to end. If this is all new, the `Option` and `Result` pages are the two that matter.

--- a/src/content/notes/id/how-ts-belt-helps-me-write-predictable-code.mdx
+++ b/src/content/notes/id/how-ts-belt-helps-me-write-predictable-code.mdx
@@ -1,0 +1,588 @@
+---
+title: "Bagaimana ts-belt Membantu Saya Menulis Kode yang Mudah Diprediksi"
+description: "ts-belt adalah utility library TypeScript buatan Mobily yang memakai pendekatan fungsional. Begini cara Option, Result, dan AsyncResult menggantikan tumpukan pengecekan null dan try/catch di kode LLM yang saya kerjakan sehari-hari."
+publishedAt: "08/09/2026"
+status: "draft"
+featured: false
+author: rimzzlabs
+keywords:
+  - TS-Belt
+  - Functional Programming Frontend
+  - Option
+  - Result
+  - LLM Frontend
+---
+
+import { PlaygroundOption } from "@/components/notes/how-ts-belt-helps-me-write-predictable-code/playground-option";
+import { PlaygroundResult } from "@/components/notes/how-ts-belt-helps-me-write-predictable-code/playground-result";
+import { PlaygroundMessages } from "@/components/notes/how-ts-belt-helps-me-write-predictable-code/playground-messages";
+
+Pertama kali tampilan _chat_ kami mendadak kosong, saya menyalahkan _backend_.
+
+Yang sebenarnya terjadi, model memanggil sebuah _tool_ dan bukan menulis balasan. Saya baru saja menulis ulang bagian _parsing_ pesan dengan ts-belt, semuanya lolos _type check_, dan tetap saja melempar `TypeError` di _production_.
+
+Satu _field_ penyebabnya. `content` bernilai `null` setiap kali model mengembalikan _tool call_, dan _pipeline_ saya memperlakukan `null` itu sebagai nilai yang sah sebelum menyerahkannya ke `.trim()`.
+
+Catatan ini tentang bagian ts-belt yang membuat _bug_ semacam itu berhenti terjadi buat saya. Sekaligus tentang satu celah yang bisa membuat kamu menulis _bug_ yang sama lagi tanpa sadar.
+
+## Pendahuluan
+
+[ts-belt](https://mobily.github.io/ts-belt/) adalah _utility library_ TypeScript buatan [Marcin Dziewulski](https://github.com/mobily), memakai pendekatan _functional programming_ dan merupakan [_utility library_ tercepat](https://mobily.github.io/ts-belt/benchmarks/introduction) yang ada saat ini.
+
+```sh
+npm install @mobily/ts-belt
+```
+
+Isinya dibagi jadi _namespace_ kecil yang diimpor per huruf:
+
+- `A` untuk _array_, `D` untuk objek biasa, `S` untuk _string_, `N` untuk angka, `B` untuk _boolean_.
+- `F` untuk _helper_ fungsi, `G` untuk _type guard_.
+- `O` untuk `Option`, `R` untuk `Result`, dan `AR` untuk `AsyncResult`.
+- `pipe` dan `flow` untuk merangkai semuanya.
+
+[Lodash](https://github.com/lodash/lodash) sebenarnya sudah cukup untuk baris pertama itu. Yang bikin saya tertarik justru sisanya.
+
+> Semua potongan kode di sini berjalan di `4.0.0-rc.5`. Modul `AR` baru ada di v4, jadi kalau kamu masih di v3, semuanya tersedia kecuali bagian _async_-nya.
+
+## Membaca Alur Kode dari Atas ke Bawah
+
+Hampir semua kode setelah ini lewat `pipe`. Itu bisa jalan karena satu keputusan desain yang diulang ts-belt di hampir semua fungsinya, jadi kita bereskan dulu bagian itu.
+
+Nyaris setiap fungsi di ts-belt punya dua _signature_. Berikan datanya lebih dulu maka ia langsung berjalan. Kosongkan datanya maka kamu mendapat fungsi yang masih menunggu data itu.
+
+```ts
+import { A } from "@mobily/ts-belt";
+
+const roles = A.map(messages, (message) => message.role);
+
+const getRoles = A.map((message: ChatMessage) => message.role);
+```
+
+Bentuk kedua ini ada supaya fungsinya bisa dibariskan di dalam `pipe`. `pipe` menerima satu nilai, lalu mengoper hasilnya ke fungsi berikutnya, satu per satu.
+
+```ts
+import { A, S, pipe } from "@mobily/ts-belt";
+
+const roles = pipe(
+  messages,
+  A.map((message) => message.role),
+  A.reject(S.isEmpty),
+  A.uniq,
+);
+```
+
+TypeScript menyimpulkan tipenya di setiap langkah, jadi `A.reject` sudah tahu bahwa yang dihadapinya adalah _string_. Tidak ada objek pembungkus, tidak ada _class_ yang perlu dipelajari, hanya fungsi yang mengoper nilai.
+
+`flow` idenya sama, cuma tanpa nilai awal, jadi yang kamu dapat fungsi siap pakai, bukan hasilnya. `pipe` mentok di sembilan fungsi, lebih dari itu pecah jadi dua.
+
+## Banyaknya Cara Jawaban Model Bisa Kosong
+
+Modul `O` adalah jawaban ts-belt untuk nilai yang belum tentu ada. Supaya kelihatan kenapa itu penting, lihat dulu apa yang sebenarnya dikirim sebuah _chat completion_:
+
+```ts
+type ToolCall = {
+  id: string;
+  function: { name: string; arguments: string };
+};
+
+type ChatMessage = {
+  role: "assistant";
+  content: string | null;
+  tool_calls?: Array<ToolCall>;
+};
+
+type ChatCompletion = {
+  choices: Array<{ message?: ChatMessage; finish_reason: string }>;
+};
+```
+
+Coba hitung ada berapa cara respons itu bisa datang tanpa isi sama sekali.
+
+`choices` bisa kosong. `message` bisa tidak ada ketika _content filter_ menyala. `content` bernilai `null` di setiap _tool call_. Dan ketika model benar-benar menjawab, kadang jawabannya cuma spasi.
+
+Jadi mengambil teks balasannya berakhir seperti ini:
+
+```ts
+const FALLBACK = "Model tidak mengembalikan teks apa pun.";
+
+function getReplyText(completion: ChatCompletion) {
+  if (completion.choices.length === 0) return FALLBACK;
+
+  const message = completion.choices[0].message;
+  if (!message) return FALLBACK;
+
+  if (message.content === null) return FALLBACK;
+
+  const text = message.content.trim();
+  if (text === "") return FALLBACK;
+
+  return text;
+}
+```
+
+Empat pengecekan, empat _early return_, dan _fallback_ yang sama diketik empat kali.
+
+Tidak ada yang salah dengan kode ini. Saya menulis bentuk persis seperti ini selama bertahun-tahun. Tapi pekerjaan sebenarnya adalah "baca balasannya", dan pekerjaan itu terkubur di bawah usaha membuktikan bahwa membacanya aman.
+
+`Option` adalah tempat keempat jenis ketiadaan tadi menjadi satu. Di kebanyakan bahasa, `Option` adalah kotak yang harus kamu buka. Di ts-belt, ia sama sekali bukan kotak:
+
+```ts
+import type { O } from "@mobily/ts-belt";
+
+type ReplyText = O.Option<string>; // string | null | undefined
+```
+
+Cuma itu isinya. `O.Option<A>` didefinisikan sebagai `A | null | undefined`, tidak lebih.
+
+Tidak ada alokasi dan tidak ada pembungkusan. Ini lebih penting daripada kedengarannya. Kamu bisa memakai `O` di satu fungsi tanpa mengubah apa pun di sekitarnya, dan hasilnya bisa langsung dikembalikan ke React atau ke fungsi mana pun yang memang menerima `string | undefined`.
+
+Setiap fungsi ts-belt yang mungkin tidak menemukan apa-apa mengembalikan `Option`:
+
+```ts
+import { A, D, S } from "@mobily/ts-belt";
+
+A.head(completion.choices); // Option<Choice>
+A.getBy(toolCalls, (call) => call.id === id); // Option<ToolCall>
+D.get(headers, "x-request-id"); // Option<string>
+S.search(reply, /\d+/); // Option<number>
+```
+
+Sekarang fungsi yang tadi, ditulis ulang:
+
+```ts
+import { A, O, S, pipe } from "@mobily/ts-belt";
+
+function getReplyText(completion: ChatCompletion) {
+  const text = pipe(
+    completion.choices,
+    A.head,
+    O.flatMap((choice) => O.fromNullable(choice.message)),
+    O.flatMap((message) => O.fromNullable(message.content)),
+    O.map(S.trim),
+    O.filter(S.isNotEmpty),
+  );
+
+  return O.getWithDefault(text, FALLBACK);
+}
+```
+
+Semua pengecekannya hilang, dan _fallback_-nya cuma muncul sekali, di akhir.
+
+Ini bisa jalan karena `O.map`, `O.flatMap`, dan `O.filter` mengikuti satu aturan yang sama. Kalau nilainya ada, jalankan fungsinya. Kalau tidak ada, lewati fungsinya dan teruskan kekosongan itu ke langkah berikutnya.
+
+Jadi kasus `choices` yang kosong tidak pernah butuh `if` sendiri. `A.head` tidak mengembalikan apa-apa, dan semua langkah sesudahnya otomatis ikut dilewati.
+
+Di lapisan komponen, `O.match` adalah cara keluar dari jalur itu sambil menangani kedua kemungkinannya secara eksplisit:
+
+```tsx
+import { O } from "@mobily/ts-belt";
+
+function ReplyBubble(props: { text: O.Option<string> }) {
+  return O.match(
+    props.text,
+    (text) => <p className="reply">{text}</p>,
+    () => <p className="reply-empty">{FALLBACK}</p>,
+  );
+}
+```
+
+### `null` yang Lolos Begitu Saja
+
+Sekarang bagian yang menghabiskan satu sore saya.
+
+Tipenya bilang `Option<A> = A | null | undefined`. Tapi yang terjadi saat program berjalan lain lagi. Di dalam ts-belt, pengecekan ketiadaannya begini:
+
+```ts
+function isNone(x) {
+  return x === void 0;
+}
+```
+
+Cuma `undefined` yang dianggap kosong. `null` diperlakukan sebagai nilai yang sah, lalu diteruskan ke fungsi berikutnya seperti nilai biasa.
+
+Artinya versi ini lolos _type check_ tanpa keluhan sedikit pun, lalu jebol begitu model memanggil _tool_:
+
+```ts
+import { A, O, S, pipe } from "@mobily/ts-belt";
+
+pipe(
+  completion.choices,
+  A.head,
+  O.flatMap((choice) => choice.message),
+  O.flatMap((message) => message.content),
+  O.map(S.trim),
+);
+```
+
+`message.content` bertipe `string | null`, dan TypeScript dengan senang hati menerimanya sebagai `Option<string>`. Tapi ketika isinya `null`, `O.map` menganggapnya `Some`, memanggil `S.trim(null)`, dan lahirlah `TypeError` tadi.
+
+Ini seperti kotak berlabel kosong yang ternyata masih ada isinya, dan labelnya adalah satu-satunya hal yang diperiksa orang.
+
+Coba sendiri di bawah. Pindah ke _tool call_ lalu lihat baris tengahnya tumbang:
+
+<PlaygroundOption client:visible lang="id" />
+
+Perbaikannya cuma satu fungsi. `O.fromNullable` mengubah `null` menjadi `undefined`:
+
+```ts
+import { O } from "@mobily/ts-belt";
+
+O.flatMap((message) => O.fromNullable(message.content));
+```
+
+Kebiasaan yang akhirnya saya pegang: apa pun yang datang dari luar _pipeline_ saya sendiri harus lewat `O.fromNullable` dulu. Respons API, `JSON.parse`, nilai dari _form_, _library_ pihak ketiga. Nilai yang diproduksi ts-belt sendiri, misalnya keluaran `A.head`, sudah bersih.
+
+Aturannya kecil, tapi inilah pembeda antara `Option` yang bisa ditebak dan `Option` yang jadi jebakan.
+
+## Memastikan Bentuk Data yang Datang dari Luar
+
+Apa pun yang dikirim balik oleh model dimulai sebagai `unknown`. `G` adalah modul yang memastikan sebuah nilai itu sebenarnya apa, dan enak dikenali sebelum masuk ke `Result`.
+
+Semua _guard_-nya mempersempit tipe dengan benar selama dipanggil langsung, jadi TypeScript ikut paham:
+
+```ts
+import { G } from "@mobily/ts-belt";
+
+G.isString(value);
+G.isNumber(value);
+G.isObject(value);
+G.isNotNullable(value);
+```
+
+Yang paling sering saya pakai adalah `G.isNotNullable`, karena ia membersihkan sebuah _array_ sekaligus mempersempit tipenya dalam satu langkah:
+
+```ts
+import { A, G, pipe } from "@mobily/ts-belt";
+
+const usages = pipe(
+  completions,
+  A.map((completion) => completion.usage), // Array<Option<Usage>>
+  A.filter(G.isNotNullable), // Array<Usage>
+);
+```
+
+Tanpa _cast_, tanpa `as`, dan _array_ yang keluar benar-benar bersih dari lubang.
+
+## Mengeluarkan Ternary dari Pipeline
+
+`F` adalah modul yang paling lama saya abaikan, dan justru modul inilah yang akhirnya mengeluarkan _ternary_ dari _pipeline_ saya.
+
+Sebuah _ternary_ tidak masalah kalau berdiri sendiri. Masalahnya, ia tidak bisa duduk di dalam `pipe`, jadi begitu kamu butuh satu saja, kamu kembali mengeluarkan nilainya ke sebuah variabel dan rantainya putus.
+
+`F.ifElse` menerima nilainya, sebuah _predicate_, lalu dua cabangnya:
+
+```ts
+import { F } from "@mobily/ts-belt";
+
+const model = F.ifElse(
+  request,
+  (value) => value.premium,
+  F.always("opus"),
+  F.always("haiku"),
+);
+```
+
+`F.always` membuat fungsi yang mengabaikan masukannya dan mengembalikan sebuah konstanta, dan itulah yang dibutuhkan kedua cabang tadi.
+
+Untuk kasus yang jauh lebih sering, yaitu "pakai ini kecuali nilainya tidak ada", ada `F.defaultTo`:
+
+```ts
+import { F } from "@mobily/ts-belt";
+
+const temperature = F.defaultTo(request.temperature, 0.7);
+```
+
+Ia berpatokan pada _nullability_, bukan _truthiness_, jadi angka `0` tetap `0`. Itu masalah klasik `||` yang sudah dibereskan `??`, bedanya yang satu ini bisa ikut dirangkai di dalam `pipe`.
+
+`F.identity` satu lagi yang layak diingat. Ia mengembalikan masukannya apa adanya, dan itu persis yang kamu mau untuk cabang "biarkan saja" pada sebuah `F.ifElse`.
+
+## Menaruh Kegagalan di Tipe Kembalian
+
+`Option` menjawab "ada atau tidak?". Ia tidak bisa memberi tahu _kenapa_ sesuatu tidak ada, dan tidak bisa membawa pesan ke pengguna. Untuk itu ada `Result`.
+
+Lihat sebuah _signature_ biasa:
+
+```ts
+function parseArguments(raw: string): SearchArgs;
+```
+
+Ia menjanjikan argumen. Ia juga bisa melempar _error_, dan tipenya tidak bilang apa-apa soal itu. Apakah kamu butuh `try/catch` hanya bisa diketahui dengan membaca isi fungsinya, dan isi semua fungsi yang dipanggilnya.
+
+Setiap `try/catch` yang kita tulis adalah pengakuan bahwa sebuah tipe telah membohongi kita.
+
+`Result` menaruh kegagalannya di tipe kembalian, tempat _compiler_ bisa melihatnya:
+
+```ts
+import type { R } from "@mobily/ts-belt";
+
+type ParsedArgs = R.Result<SearchArgs, Error>; // Ok<SearchArgs> | Error<Error>
+```
+
+Berbeda dengan `Option`, yang satu ini benar-benar pembungkus. Isinya objek kecil bertanda yang menyimpan nilainya atau _error_-nya, dan kamu tidak bisa membaca nilainya tanpa memutuskan lebih dulu apa yang terjadi kalau nilainya tidak ada.
+
+Mendapatkannya dari kode yang melempar _error_ cuma butuh satu fungsi:
+
+```ts
+import { R } from "@mobily/ts-belt";
+
+const parsed = R.fromExecution(() => JSON.parse(raw) as unknown);
+const answer = await R.fromPromise(callModel(prompt));
+```
+
+`R.fromExecution` menangani apa pun yang sinkron, `R.fromPromise` menangani _promise_, dan keduanya mengembalikan `Result` yang sisi _error_-nya berupa `Error` sungguhan.
+
+### Menumpuk Langkah yang Bisa Gagal
+
+Manfaatnya terasa ketika beberapa langkah bisa gagal secara beruntun.
+
+Ketika model memanggil sebuah _tool_, argumennya datang sebagai _string_ mentah. Ia harus di-_parse_, lalu harus diperiksa, karena tidak ada jaminan model mengisi _field_ yang kita minta.
+
+Percobaan pertama saya untuk bagian pemeriksaan itu adalah tumpukan `G` dengan _early return_ di tiap langkahnya. Jalan, tapi itu satu-satunya bagian yang masih imperatif di _file_ tersebut, dan cukup mengganjal sampai saya coba tulis ulang sebagai `pipe`.
+
+Di situlah saya menabrak tembok.
+
+```ts
+import { G, R, pipe } from "@mobily/ts-belt";
+
+pipe(
+  R.fromPredicate(value, G.isObject, new Error("not an object")),
+  R.map((object) => object.query),
+);
+```
+
+Kode ini tidak bisa di-_compile_, dan alasannya layak diketahui. `R.fromPredicate` di sini menghasilkan `Result<{}, Error>`. _Guard_-nya tetap jalan, tapi hasil penyempitan tipenya hilang di tengah jalan.
+
+`A.filter` adalah pengecualiannya. Ia punya _overload_ khusus yang membawa _type predicate_ sampai ke ujung, dan itulah sebabnya `A.filter(G.isNotNullable)` tadi berhasil mempersempit tipe _array_-nya. `O.filter` dan `R.fromPredicate` tidak punya _overload_ semacam itu, jadi tipe apa pun yang lewat situ keluar sama luasnya seperti waktu masuk.
+
+Jadi `G` gunanya mempersempit tipe nilai yang sudah kamu pegang. Ia tidak bisa mengubah `unknown` jadi sebuah bentuk yang pasti. Untuk itu kamu butuh _schema_, dan di proyek ini saya memang sudah pakai [zod](https://zod.dev):
+
+```ts
+import { R } from "@mobily/ts-belt";
+import { z } from "zod";
+
+const searchArgsSchema = z.object({
+  query: z.string(),
+  limit: z.number().default(10),
+});
+
+type SearchArgs = z.infer<typeof searchArgsSchema>;
+
+function parseArguments(raw: string): R.Result<unknown, Error> {
+  return R.fromExecution(() => JSON.parse(raw) as unknown);
+}
+
+function toSearchArgs(value: unknown) {
+  return R.fromExecution(() => searchArgsSchema.parse(value));
+}
+```
+
+Tumpukan pengecekannya hilang. `searchArgsSchema.parse` melempar _error_ kalau bentuknya salah, `R.fromExecution` menangkapnya, dan yang kembali adalah `Result<SearchArgs, Error>` yang tipenya rapi. Nilai bawaan untuk `limit` pindah ke dalam _schema_, tempat yang memang lebih enak dibaca.
+
+Ini pembagian tugas yang akhirnya saya pakai. zod memutuskan data itu _apa_. ts-belt memutuskan langkah-langkahnya _mengalir_ ke mana.
+
+Dan sekarang kedua bagiannya masing-masing tinggal satu langkah, jadi keduanya nyambung:
+
+```ts
+import { R, pipe } from "@mobily/ts-belt";
+
+function readSearchArgs(toolCall: ToolCall) {
+  return pipe(
+    parseArguments(toolCall.function.arguments),
+    R.flatMap(toSearchArgs),
+    R.mapError((error) => error.message),
+  );
+}
+```
+
+`R.flatMap` menuruti aturan yang sama dengan `O.flatMap`. Kalau yang masuk berupa `Ok`, jalankan langkah berikutnya. Kalau sudah berupa `Error`, lewati langkahnya sama sekali dan teruskan _error_-nya ke bawah tanpa disentuh.
+
+Bayangkan sebuah berkas yang melewati deretan loket. Loket satu mem-_parsing_-nya, loket dua memeriksanya, loket tiga menjalankan pencariannya. Begitu satu loket menolak, berkasnya dapat surat penolakan dan langsung menuju pintu keluar. Loket-loket sesudahnya tidak membuka mapnya, dan tidak ada loket yang perlu bertanya "ini sudah ditolak belum?" di awal meja.
+
+Pertanyaan itulah yang sebenarnya dilakukan `try/catch` di sekeliling setiap langkah.
+
+`R.mapError` di baris terakhir perlu dijelaskan sedikit. Di dalam _pipeline_, _error_-nya berupa `Error` sungguhan, dan itu yang kita mau di _log_. Komponennya cuma butuh _string_. `R.mapError` menerjemahkan yang satu ke yang lain tanpa pernah menyentuh jalur suksesnya.
+
+Satu catatan sekarang setelah zod ikut di rantai ini. `ZodError` menyimpan `message`-nya sebagai _dump_ JSON dari setiap masalah, dan itu tidak terbaca kalau ditaruh di _toast_. `z.prettifyError` yang perlu kamu panggil di situ.
+
+Rusakkan JSON di bawah lalu lihat langkah dua dilewati:
+
+<PlaygroundResult client:visible lang="id" />
+
+### Membukanya di Tempat Hasilnya Dirender
+
+Sebuah `Result` sebaiknya tidak bepergian jauh. Saya menyimpannya di dalam modul yang membuatnya, lalu membukanya di tempat hasilnya dirender:
+
+```tsx
+import { R } from "@mobily/ts-belt";
+
+function ToolCallStatus(props: { result: R.Result<SearchArgs, string> }) {
+  return R.match(
+    props.result,
+    (args) => <p>Mencari {args.query}</p>,
+    (message) => <p role="alert">{message}</p>,
+  );
+}
+```
+
+`R.match` memaksa kedua cabangnya ada. Kamu tidak bisa merender jalur suksesnya lalu diam-diam melupakan yang satunya. Itu kesalahan yang lebih dari sekali saya rilis waktu masih pakai `try/catch` biasa.
+
+## Ketika Separuh Langkahnya Berupa Promise
+
+Ada satu masalah dengan semua yang di atas: di kode _agent_, hampir tidak ada yang sinkron.
+
+Panggilan ke model adalah _promise_. _Tool_-nya adalah _promise_. Di antara keduanya ada _parsing_, yang bukan _promise_. Jadi kamu berakhir dengan satu `await`, lalu sebuah `Result`, lalu `await` lagi, dan _pipeline_ yang sedang kamu bangun berantakan jadi tumpukan variabel perantara.
+
+`AsyncResult` adalah jawaban v4, dan definisinya sesederhana yang kamu harapkan:
+
+```ts
+import type { AR } from "@mobily/ts-belt";
+
+type Turn = AR.AsyncResult<Array<string>, Error>; // Promise<Result<Array<string>, Error>>
+```
+
+Sebuah `AsyncResult<A, B>` adalah `Promise<Result<A, B>>`, dengan kombinator yang sudah kamu kenal. `AR.fold` menerima langkah yang mengembalikan `Result` biasa, `AR.flatMap` menerima langkah yang mengembalikan `AsyncResult` lagi, dan `AR.match` membuka semuanya di akhir.
+
+Artinya satu giliran _agent_, dari _prompt_ sampai jawaban yang dirender, jadi satu ekspresi:
+
+```ts
+import { AR, pipe } from "@mobily/ts-belt";
+
+function runTurn(prompt: string) {
+  return pipe(
+    AR.make(callModel(prompt)),
+    AR.fold(firstToolCall),
+    AR.fold((toolCall) => parseArguments(toolCall.function.arguments)),
+    AR.fold(toSearchArgs),
+    AR.flatMap((args) => AR.make(runSearch(args))),
+    AR.match(
+      (results) => `Ditemukan ${results.length} hasil`,
+      (error) => `Giliran ini gagal: ${error.message}`,
+    ),
+  );
+}
+```
+
+Ada lima hal yang bisa gagal di sana. Modelnya bisa kena _rate limit_, bisa saja tidak memanggil _tool_ sama sekali, argumennya bisa rusak, bentuknya bisa salah, dan pencariannya sendiri bisa mati.
+
+Tidak ada satu pun `try` di seluruh fungsi itu, dan setiap kegagalan tadi mendarat di tempat yang sama lengkap dengan pesannya.
+
+`AR.make` yang membungkus _promise_ biasa jadi `AsyncResult`, sekaligus menangkap _rejection_-nya. Jadi `429` yang dilempar datang sebagai `Error`, bukan meledakkan rantainya.
+
+Langkah yang mencari _tool call_-nya hanyalah pekerjaan `Option` yang diserahkan ke `Result`:
+
+```ts
+import { A, O, R, pipe } from "@mobily/ts-belt";
+
+function firstToolCall(completion: ChatCompletion): R.Result<ToolCall, Error> {
+  const toolCall = pipe(
+    completion.choices,
+    A.head,
+    O.flatMap((choice) => O.fromNullable(choice.message)),
+    O.flatMap((message) => O.fromNullable(message.tool_calls)),
+    O.flatMap(A.head),
+  );
+
+  return R.fromNullable(toolCall, new Error("Model tidak memanggil tool"));
+}
+```
+
+`R.fromNullable` jembatannya. `Option` cuma bisa bilang "tidak ada apa-apa di sini", lalu kamu tempelkan alasannya dan serahkan ke `Result`.
+
+## Merapikan Data Sebelum Dikirim Keluar
+
+`A` untuk _array_ dan `D` untuk objek biasa adalah bagian _library_ yang paling tidak menarik, sekaligus yang paling sering saya pakai.
+
+Sebelum sebuah _prompt_ dikirim, riwayatnya perlu dirapikan. Buang pesan _system_-nya, buang giliran ketika model cuma memanggil _tool_, potong spasinya, singkirkan kolom internalnya, lalu pangkas sampai muat di _context window_.
+
+Ada lima hal di situ, dan jadinya lima baris:
+
+```ts
+import { A, D, O, S, pipe } from "@mobily/ts-belt";
+
+function toPromptMessages(messages: Array<StoredMessage>) {
+  return pipe(
+    messages,
+    A.reject((message) => message.role === "system"),
+    A.filterMap((message) =>
+      pipe(
+        O.fromNullable(message.content),
+        O.map(S.trim),
+        O.filter(S.isNotEmpty),
+        O.map((content) =>
+          D.merge(D.selectKeys(message, ["role"]), { content }),
+        ),
+      ),
+    ),
+    A.take(20),
+  );
+}
+```
+
+`A.filterMap` yang paling layak diingat. Ia mem-_map_ dan mem-_filter_ sekaligus dalam satu jalan, dan penentunya cuma satu: fungsimu mengembalikan sebuah nilai, atau tidak mengembalikan apa-apa.
+
+`D.selectKeys` memilih _field_ yang memang diminta API, jadi `created_at` dan `trace_id` tidak ikut terkirim.
+
+Nyalakan dan matikan langkahnya lalu lihat apa yang dibuang masing-masing:
+
+<PlaygroundMessages client:visible lang="id" />
+
+Menghitung token sepanjang satu sesi bentuknya sama:
+
+```ts
+import { A, G, N, pipe } from "@mobily/ts-belt";
+
+function totalTokens(completions: Array<ChatCompletion>) {
+  return pipe(
+    completions,
+    A.map((completion) => completion.usage),
+    A.filter(G.isNotNullable),
+    A.reduce(0, (sum, usage) =>
+      N.add(sum, usage.prompt_tokens + usage.completion_tokens),
+    ),
+  );
+}
+```
+
+## Apa Konsekuensinya
+
+Saya lebih suka menulis bagian ini daripada membiarkan kamu menemukannya sendiri pas lagi dikejar rilis.
+
+**`null` bukan `None` saat program berjalan.** Yang tadi di atas, dan satu-satunya di daftar ini yang benar-benar bisa bikin _crash_. `O.fromNullable` di setiap perbatasan.
+
+**_Array_ kembali sebagai `readonly`.** `A.map` mengembalikan `readonly T[]`, jadi menugaskannya ke `Array<string>` tidak akan lolos _compile_. Biasanya kamu tinggal menulis _signature_-mu sendiri sebagai `ReadonlyArray<T>` lalu lanjut. Kalau itu terlalu banyak perubahan, ada jalan keluar global yang cukup dideklarasikan sekali, dan ia butuh `skipLibCheck: true`:
+
+```ts
+declare global {
+  namespace Belt {
+    type UseMutableArrays = 1;
+  }
+}
+
+export {};
+```
+
+**Kedua cabang `match` harus sepakat soal tipe kembaliannya.** _Generic_-nya dikunci oleh _callback_ mana pun yang datang duluan, jadi ketika cabang kedua mengembalikan bentuk yang sedikit berbeda, _error_-nya menunjuk ke tempat yang salah. Anotasikan tipe kembaliannya dan masalahnya hilang.
+
+**`R.Error` bukan `Error` milik JavaScript.** Ia wadah yang bisa menampung apa saja, termasuk _string_ biasa. Justru itu gunanya, karena nilai _error_ yang bertipe memang membantu. Tapi kalau kamu `throw` benda ini, _stack trace_ yang kamu dapat benar-benar membingungkan.
+
+**`Option` tidak bisa bersarang.** `Option<Option<string>>` runtuh jadi satu, karena ia _union_ dan bukan kotak. Jadi `D.get(config, "model")` tidak bisa membedakan antara "_key_-nya tidak ada" dan "_key_-nya ada dan isinya `undefined`". Kalau perbedaan itu penting, pakai `Result`.
+
+**Dan harga yang bukan soal teknis.** Sebuah `pipe` berisi enam fungsi baru lebih enak dibaca kalau pembacanya tahu apa itu `flatMap`. Di tim yang belum pernah lihat gaya ini, kodenya bukan jadi lebih jelas, cuma jadi asing. Saya memasukkannya di tempat yang manfaatnya jelas, yaitu apa pun yang menyentuh jaringan atau merapikan data, dan saya biarkan `if` biasa di tempat yang memang sudah paling jelas dibaca.
+
+## Penutup
+
+`if` tidak pernah jadi masalahnya.
+
+Masalahnya, sebuah `if` yang sifatnya berjaga-jaga terlihat persis seperti aturan bisnis. Beberapa bulan kemudian, tidak ada yang bisa membedakan cabang mana yang mewakili kebutuhan nyata dan cabang mana yang cuma ada supaya TypeScript diam.
+
+Yang akhirnya melekat buat saya:
+
+1. Pakai `Option` kalau pertanyaannya cuma "ada atau tidak?", dan `Result` kalau kamu juga berutang alasan ke seseorang.
+2. Lewatkan apa pun dari luar _pipeline_-mu ke `O.fromNullable` sebelum fungsi `O` lain menyentuhnya.
+3. Bungkus kode yang melempar _error_ sekali saja dengan `R.fromExecution` atau `R.fromPromise`, lalu rangkai dengan `R.flatMap` alih-alih menumpuk `try/catch`.
+4. Kalau langkahnya campuran sinkron dan _async_, pakai `AR` daripada membuka bungkusnya di antara setiap `await`.
+5. Simpan `Result` di dalam modul yang membuatnya dan buka dengan `R.match` di batas komponen, supaya kedua cabangnya wajib ada.
+
+Semua ini tidak membuat kemungkinan gagalnya hilang. Yang berubah, kemungkinan itu pindah ke _type signature_ tempat _compiler_ bisa menunjuknya, bukan lagi bersembunyi di badan fungsi yang cuma ketahuan kalau dibaca teliti.
+
+[Dokumentasi ts-belt](https://mobily.github.io/ts-belt/) pendek dan layak dibaca sampai habis. Kalau semua ini baru buat kamu, halaman `Option` dan `Result` adalah dua yang paling penting.


### PR DESCRIPTION
## Summary

Adds "How ts-belt Helps Me Write Predictable Code" in English and Indonesian, plus three interactive playgrounds.

The note is grouped by ts-belt's API surface but every example comes from LLM and agent code: chat completions, tool calls, message history, and token usage. It covers `Option`, `Result`, `AsyncResult`, and the `Array`, `Dict`, `Guards`, and `Function` modules.

**Both notes stay `status: "draft"`, so a merge does not publish them.** Flip the two frontmatter lines when you want them live.

## Playgrounds

Three React islands, hydrated with `client:visible`, running ts-belt in the browser:

1. **The `Option` trap** — pick a response shape and watch the pipeline without `O.fromNullable` throw on a tool call, next to the version that survives.
2. **The `Result` chain** — edit tool call arguments and watch step two get skipped when the JSON breaks.
3. **An `Array` and `Dict` pipeline** — toggle each step and see what it removes from a conversation.

Each takes a required `lang` prop and holds its copy in a `Record<Lang, Copy>`, including the sample data, so the Indonesian note is localized in full.

## Two findings the note documents

Both verified against `@mobily/ts-belt@4.0.0-rc.5`, the version this repo pins.

- **`null` is not `None` at runtime.** The type is `Option<A> = A | null | undefined`, but the runtime check is `x === void 0`. A `null` passes as `Some`, so `O.map` calls its function with `null` and throws. This is the bug the note opens on, and it is real: `content` is `null` on every tool call.
- **Only `A.filter` carries type-guard narrowing.** `O.filter` and `R.fromPredicate` have no `value is B` overload, so `R.fromPredicate(value, G.isObject, err)` on an `unknown` returns `Result<{}, Error>`. That is why validation uses zod for the shape and ts-belt for the flow.

## File layout

Note specific components live in `src/components/notes/<note-slug>/`, matching how images already sit in `src/assets/notes/<note-slug>/`. The shared frame stays note agnostic at `src/components/notes/playground.tsx` so a future note can reuse it.

## Verification

- Every code snippet in the note was compiled under `tsc --strict` and executed against the pinned ts-belt build.
- `pnpm check` and Biome are clean.
- Built with both notes temporarily published: all three islands hydrate on the English and Indonesian pages, and all 13 headings render.

## Not included

`astro.config.mjs` has an uncommitted local change (`shikiConfig.wrap` from `true` to `false`) that predates this work. I left it out of this branch.
