### PR TITLE
fix(notes): stop wrapping long lines in code blocks

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -57,7 +57,7 @@ export default defineConfig({
 		syntaxHighlight: "shiki",
 		shikiConfig: {
 			themes: { light: "github-light-default", dark: "github-dark-default" },
-			wrap: true,
+			wrap: false,
 		},
 		processor: unified({ rehypePlugins: [rehypeSlug, rehypeAutolinkHeadings] }),
 	},


### PR DESCRIPTION
## Summary

Set the Shiki `wrap` option to `false` in `astro.config.mjs`.

Long lines in a code block now scroll horizontally. Before this change, long lines wrapped onto the next line.

## Reason

A wrapped line breaks the visual shape of a `pipe` chain. Each step must stay on one line to stay readable.

## Rendered difference

The `style` attribute on the `pre` element changes.

- Before: `overflow-x:auto;white-space:pre-wrap`
- After: `overflow-x:auto`

## Verification

Run `pnpm build`. The build completes with no errors. Open any note page and inspect a code block.
