### PR TITLE
feat(notes): publish How ts-belt Helps Me Write Predictable Code (en+id)

### DIFF
--- a/src/content/notes/en/how-ts-belt-helps-me-write-predictable-code.mdx
+++ b/src/content/notes/en/how-ts-belt-helps-me-write-predictable-code.mdx
@@ -2,7 +2,7 @@
 title: "How ts-belt Helps Me Write Predictable Code"
 description: "ts-belt is a TypeScript utility library created by Mobily that uses a functional approach. Here is how Option, Result, and AsyncResult replaced the pile of null checks and try/catch in the LLM code I work on every day."
 publishedAt: "08/09/2026"
-status: "draft"
+status: "published"
 featured: false
 author: rimzzlabs
 keywords:

--- a/src/content/notes/id/how-ts-belt-helps-me-write-predictable-code.mdx
+++ b/src/content/notes/id/how-ts-belt-helps-me-write-predictable-code.mdx
@@ -2,7 +2,7 @@
 title: "Bagaimana ts-belt Membantu Saya Menulis Kode yang Mudah Diprediksi"
 description: "ts-belt adalah utility library TypeScript buatan Mobily yang memakai pendekatan fungsional. Begini cara Option, Result, dan AsyncResult menggantikan tumpukan pengecekan null dan try/catch di kode LLM yang saya kerjakan sehari-hari."
 publishedAt: "08/09/2026"
-status: "draft"
+status: "published"
 featured: false
 author: rimzzlabs
 keywords:


### PR DESCRIPTION
## Summary

Change the `status` field of both notes from `draft` to `published`.

PR #150 added the note content. This PR makes the note public.

## Effect

- The note appears on the English and Indonesian note index pages.
- The note appears in the sitemap.
- The markdown variants under `/md` serve the note to agents.

## Verification

Run `pnpm build`. The build completes with no errors and produces 26 pages.

- Both index pages link to the note.
- The sitemap contains the note URL.
- Each note page renders 13 headings and hydrates 3 playground islands.
