### PR TITLE
feat(guestbook): tag messages written in the other locale

### DIFF
--- a/functions/_lib/guestbook.ts
+++ b/functions/_lib/guestbook.ts
@@ -1,3 +1,5 @@
+import type { Lang } from "../../src/i18n/config";
+
 export interface D1Result<T> {
 	results: T[];
 }
@@ -37,6 +39,7 @@ export interface CommentRow {
 	name: string;
 	site: string | null;
 	message: string;
+	lang: Lang;
 	createdAt: number;
 	updatedAt: number | null;
 	author_type: AuthorType;
@@ -50,6 +53,7 @@ export type GuestbookCommentDTO = {
 	name: string;
 	site: string | null;
 	message: string;
+	lang: Lang;
 	createdAt: number;
 	updatedAt: number | null;
 	authorType: AuthorType;
@@ -60,7 +64,7 @@ export type GuestbookCommentDTO = {
 export type Viewer = { ownerHash: string | null; sub: string | null };
 
 export const COMMENT_COLUMNS =
-	"id, name, site, message, created_at AS createdAt, updated_at AS updatedAt, author_type, author_id, avatar_url, owner_hash";
+	"id, name, site, message, lang, created_at AS createdAt, updated_at AS updatedAt, author_type, author_id, avatar_url, owner_hash";
 
 const OWNER_COOKIE = "gb_owner";
 const OWNER_MAX_AGE = 60 * 60 * 24 * 365;
@@ -107,6 +111,7 @@ export function toComment(row: CommentRow, viewer: Viewer): GuestbookCommentDTO 
 		name: row.name,
 		site: row.site,
 		message: row.message,
+		lang: row.lang,
 		createdAt: row.createdAt,
 		updatedAt: row.updatedAt,
 		authorType: row.author_type,

--- a/functions/api/guestbook.ts
+++ b/functions/api/guestbook.ts
@@ -68,12 +68,13 @@ async function insertComment(
 	row: Omit<CommentRow, "id" | "updatedAt">,
 ): Promise<number> {
 	const { meta } = await env.DB.prepare(
-		"INSERT INTO comments (name, site, message, created_at, author_type, author_id, avatar_url, owner_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+		"INSERT INTO comments (name, site, message, lang, created_at, author_type, author_id, avatar_url, owner_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
 	)
 		.bind(
 			row.name,
 			row.site,
 			row.message,
+			row.lang,
 			row.createdAt,
 			row.author_type,
 			row.author_id,
@@ -135,6 +136,7 @@ export async function onRequestPost(context: FunctionContext): Promise<Response>
 			name: sessionUser.name,
 			site,
 			message: parsed.data.message,
+			lang: parsed.data.lang,
 			createdAt,
 			author_type: provider,
 			author_id: sessionUser.id,
@@ -147,6 +149,7 @@ export async function onRequestPost(context: FunctionContext): Promise<Response>
 			name: sessionUser.name,
 			site,
 			message: parsed.data.message,
+			lang: parsed.data.lang,
 			createdAt,
 			updatedAt: null,
 			authorType: provider,
@@ -177,6 +180,7 @@ export async function onRequestPost(context: FunctionContext): Promise<Response>
 		name: parsed.data.name,
 		site,
 		message: parsed.data.message,
+		lang: parsed.data.lang,
 		createdAt,
 		author_type: "anon",
 		author_id: null,
@@ -189,6 +193,7 @@ export async function onRequestPost(context: FunctionContext): Promise<Response>
 		name: parsed.data.name,
 		site,
 		message: parsed.data.message,
+		lang: parsed.data.lang,
 		createdAt,
 		updatedAt: null,
 		authorType: "anon",

--- a/functions/api/guestbook/[id].ts
+++ b/functions/api/guestbook/[id].ts
@@ -1,3 +1,4 @@
+import type { Lang } from "../../../src/i18n/config";
 import {
 	API_VALIDATION,
 	guestbookEditSchema,
@@ -72,27 +73,32 @@ export async function onRequestPatch(context: ItemContext): Promise<Response> {
 	let name = auth.row.name;
 	let site: string | null;
 	let message: string;
+	// The edit re-stamps the language, because the writer rewrote the message on
+	// the locale they are on now.
+	let lang: Lang;
 	if (auth.row.author_type === "anon") {
 		const parsed = editSchema.safeParse(body);
 		if (!parsed.success) return json({ error: "invalid_input" }, 400);
 		name = parsed.data.name;
 		site = normalizeSite(parsed.data.site);
 		message = parsed.data.message;
+		lang = parsed.data.lang;
 	} else {
 		const parsed = verifiedSchema.safeParse(body);
 		if (!parsed.success) return json({ error: "invalid_input" }, 400);
 		site = normalizeSite(parsed.data.site);
 		message = parsed.data.message;
+		lang = parsed.data.lang;
 	}
 
 	const updatedAt = Date.now();
 	await context.env.DB.prepare(
-		"UPDATE comments SET name = ?, site = ?, message = ?, updated_at = ? WHERE id = ?",
+		"UPDATE comments SET name = ?, site = ?, message = ?, lang = ?, updated_at = ? WHERE id = ?",
 	)
-		.bind(name, site, message, updatedAt, id)
+		.bind(name, site, message, lang, updatedAt, id)
 		.run();
 
-	const item = toComment({ ...auth.row, name, site, message, updatedAt }, auth.viewer);
+	const item = toComment({ ...auth.row, name, site, message, lang, updatedAt }, auth.viewer);
 	context.waitUntil(triggerRebuild(context.env));
 	return json({ item }, 200);
 }

--- a/migrations/0005_add_message_lang.sql
+++ b/migrations/0005_add_message_lang.sql
@@ -1,0 +1,7 @@
+-- Language the message was written in, so the UI can tag a comment that does
+-- not match the locale the reader is on.
+-- Apply:  pnpm wrangler d1 migrations apply guestbook --local   (and --remote)
+ALTER TABLE comments ADD COLUMN lang TEXT NOT NULL DEFAULT 'en';
+
+-- Every comment written before this column existed is Indonesian.
+UPDATE comments SET lang = 'id';

--- a/src/components/home/guestbook/guestbook-edit-dialog.tsx
+++ b/src/components/home/guestbook/guestbook-edit-dialog.tsx
@@ -60,6 +60,7 @@ function GuestbookEditForm(props: { lang: Lang; comment: GuestbookComment; onDon
 			name: props.comment.name,
 			site: props.comment.site ?? "",
 			message: props.comment.message,
+			lang: props.lang,
 		},
 	});
 

--- a/src/components/home/guestbook/guestbook-form.tsx
+++ b/src/components/home/guestbook/guestbook-form.tsx
@@ -20,7 +20,7 @@ export function GuestbookForm(props: GuestbookFormProps) {
 
 	const methods = useForm<GuestbookInput>({
 		resolver: zodResolver(schema),
-		defaultValues: { name: "", site: "", message: "", token: "" },
+		defaultValues: { name: "", site: "", message: "", token: "", lang: props.lang },
 	});
 	const { handleSubmit, setValue, watch, reset, formState } = methods;
 

--- a/src/components/home/guestbook/guestbook-item.tsx
+++ b/src/components/home/guestbook/guestbook-item.tsx
@@ -39,6 +39,9 @@ export function GuestbookItem(props: {
 	const comment = props.comment;
 	const isVerified = comment.authorType !== "anon";
 	const authorId = `gb-author-${comment.id}`;
+	// Only tag the message when it differs from the page locale — a redundant
+	// lang makes a screen reader announce a language switch that never happened.
+	const messageLang = comment.lang === props.lang ? undefined : comment.lang;
 
 	const timestamp = useTimestamp(comment.createdAt, props.lang);
 
@@ -47,7 +50,10 @@ export function GuestbookItem(props: {
 	}
 
 	return (
-		<article className="relative rounded-lg border bg-card p-4 sm:p-5" aria-labelledby={authorId}>
+		<article
+			className="relative border-b pb-5 pt-2 group-last-of-type/messages:border-none"
+			aria-labelledby={authorId}
+		>
 			<div aria-hidden className="w-2 bg-primary/70 left-0 inset-y-0" />
 			<div className="flex items-start gap-2">
 				<Quote aria-hidden="true" className="size-5 fill-primary/20 text-primary/20" />
@@ -80,7 +86,10 @@ export function GuestbookItem(props: {
 				)}
 			</div>
 
-			<blockquote className="mt-1 text-sm leading-relaxed text-pretty italic text-foreground/85">
+			<blockquote
+				lang={messageLang}
+				className="mt-1 text-sm leading-relaxed text-pretty italic text-foreground/85"
+			>
 				{comment.message}
 			</blockquote>
 

--- a/src/components/home/guestbook/guestbook-verified-form.tsx
+++ b/src/components/home/guestbook/guestbook-verified-form.tsx
@@ -22,7 +22,7 @@ export function GuestbookVerifiedForm(props: GuestbookVerifiedFormProps) {
 
 	const methods = useForm<GuestbookVerifiedInput>({
 		resolver: zodResolver(schema),
-		defaultValues: { site: "", message: "" },
+		defaultValues: { site: "", message: "", lang: props.lang },
 	});
 
 	const onSubmit = methods.handleSubmit((values) => {

--- a/src/components/home/guestbook/guestbook.astro
+++ b/src/components/home/guestbook/guestbook.astro
@@ -34,7 +34,7 @@ const preview = await getRecentCommentsAtBuild(5);
     class="mt-6 flex flex-col gap-3 border-t pt-6 sm:flex-row sm:items-center sm:justify-between"
   >
     <p class="text-balance text-sm text-muted-foreground">{t.previewNote}</p>
-    <Link href={href} variant="ghost">
+    <Link href={href} variant="outline">
       {t.openGuestbook}
       <ArrowRight />
     </Link>

--- a/src/lib/guestbook-build.ts
+++ b/src/lib/guestbook-build.ts
@@ -1,17 +1,19 @@
 import { CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN } from "astro:env/server";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
+import type { Lang } from "../i18n/config";
 import type { AuthorType, GuestbookComment, GuestbookPage } from "./guestbook-schema";
 
 const EMPTY: GuestbookPage = { items: [], nextOffset: null };
 const LOCAL_D1_DIR = ".wrangler/state/v3/d1/miniflare-D1DatabaseObject";
 const SELECT =
-	"SELECT id, name, site, message, created_at AS createdAt, updated_at AS updatedAt, author_type AS authorType, avatar_url AS avatar FROM comments ORDER BY id DESC LIMIT ?";
+	"SELECT id, name, site, message, lang, created_at AS createdAt, updated_at AS updatedAt, author_type AS authorType, avatar_url AS avatar FROM comments ORDER BY id DESC LIMIT ?";
 
 type D1Row = {
 	id: number;
 	name: string;
 	site: string | null;
 	message: string;
+	lang: Lang;
 	createdAt: number;
 	updatedAt: number | null;
 	authorType: AuthorType;
@@ -25,6 +27,7 @@ function toPage(rows: D1Row[], limit: number): GuestbookPage {
 		name: row.name,
 		site: row.site,
 		message: row.message,
+		lang: row.lang,
 		createdAt: row.createdAt,
 		updatedAt: row.updatedAt ?? null,
 		authorType: row.authorType,

--- a/src/lib/guestbook-schema.ts
+++ b/src/lib/guestbook-schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { LOCALES } from "../i18n/config";
 import { interpolate } from "../i18n/utils";
 
 export const GUESTBOOK_LIMITS = { name: 100, site: 200, message: 500 } as const;
@@ -31,6 +32,8 @@ function tooLong(template: string, max: number) {
 
 function verifiedFields(t: GuestbookValidation) {
 	return {
+		// The locale of the page the writer used — stamped by the form, never typed.
+		lang: z.enum(LOCALES),
 		site: z
 			.string()
 			.trim()
@@ -76,6 +79,7 @@ export const guestbookCommentSchema = z.object({
 	name: z.string(),
 	site: z.string().nullable(),
 	message: z.string(),
+	lang: z.enum(LOCALES),
 	createdAt: z.number(),
 	updatedAt: z.number().nullable(),
 	authorType: z.enum(AUTHOR_TYPES),


### PR DESCRIPTION
## What

A guestbook message can be written in a language that does not match the page the reader is on. The markup gave no signal, so a screen reader read an Indonesian message with an English voice.

Each comment now stores the locale of the page the writer used, and the item tags the quote only when the two differ.

## How

**Database.** Migration `0005_add_message_lang.sql` adds `lang TEXT NOT NULL DEFAULT 'en'` and sets every existing comment to `id`. All four messages in the guestbook today are Indonesian.

**Write path.** `lang` joins the shared field set in `guestbook-schema.ts`, so the create, verified, and edit payloads all carry it. The three forms pass the current locale as a default value, so nobody types it. `POST` writes the column. `PATCH` re-stamps it, because the writer rewrote the message on the locale they are on now.

**Read path.** `guestbook-item.tsx` computes:

```tsx
const messageLang = comment.lang === props.lang ? undefined : comment.lang;
```

The `<blockquote>` gets `lang={messageLang}`. A matching language adds no attribute, so the browser announces no language switch. A different language switches pronunciation for the quote alone. The author name and the timestamp stay in the page language.

`guestbook-build.ts` selects `lang` too, so the baked snapshot carries the tag before the island hydrates.

## Deploy order

Apply the migration to the remote database before this merges:

```
pnpm wrangler d1 migrations apply guestbook --remote
```

The build-time snapshot query selects `lang`. Against an unmigrated database the query fails and the page bakes an empty preview.

## Limits

The stamp is the page locale, not the language of the text. A person on `/guestbook` who writes Indonesian gets `lang="en"`. That is the only signal available at write time. Text language detection is a separate change, and it needs no schema work.

## Also in this branch

Two small guestbook UI changes that were already in the working tree: the item is a bottom border instead of a card, and the "open guestbook" link is `outline` instead of `ghost`.

## Verify

- `pnpm check` — 0 errors
- `tsc --noEmit` — clean
- Migration applied to local D1
