### PR TITLE
fix(dev): serve the API in functions/ from the dev server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This is the canonical guide for agents working in this repo (`CLAUDE.md` points 
 
 Package manager is **pnpm**.
 
-- `pnpm dev` — dev server (`astro dev`)
+- `pnpm dev` — dev server (`astro dev`); also starts `wrangler pages dev` on 8788 for the API in `functions/`
 - `pnpm build` — production build (`astro build`)
 - `pnpm check` — TypeScript + Astro type check (`astro check`); run this to verify changes
 - `pnpm lint` — Biome lint + format check
@@ -84,3 +84,4 @@ There is no test suite. Verify with `pnpm check`; also `pnpm build` when touchin
 - **`.astro/` is generated and gitignored** — never commit it.
 - **`astro:assets` `<Image>` works only in `.astro` files**, not React islands. Inside React use a plain `<img>` (with `width`/`height`); import images as metadata (`import img from "@/assets/x.webp"` → `{ src, width, height }`).
 - **Remote-image builds need Sharp** — `<Image>`/`getImage` over the thesvg CDN requires Sharp, whose build script pnpm skips by default. Enable it with `pnpm approve-builds` (select `sharp`) or `pnpm build` will fail.
+- **The API in `functions/` is not served by `astro dev`** — Pages Functions need the workerd runtime. The `pagesFunctionsDev` Vite plugin (`scripts/pages-functions-dev.mjs`) starts `wrangler pages dev` on port 8788 with the dev server, and `vite.server.proxy` sends `/api` there. Local D1 and `.dev.vars` apply, so the guestbook works in dev. Port 8788 must be free. `pnpm guestbook:preview` still serves the built `dist` when you need the baked snapshot.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig, envField, fontProviders } from "astro/config";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeSlug from "rehype-slug";
+import { PAGES_FUNCTIONS_PORT, pagesFunctionsDev } from "./scripts/pages-functions-dev.mjs";
 
 // https://astro.build/config
 export default defineConfig({
@@ -76,12 +77,15 @@ export default defineConfig({
 	],
 
 	vite: {
+		server: {
+			proxy: { "/api": { target: `http://127.0.0.1:${PAGES_FUNCTIONS_PORT}` } },
+		},
 		build: {
 			// The only chunk over the default 500 kB is the contact form's rich-text
 			// editor (Tiptap + ProseMirror), which is lazy-loaded on dialog open and
 			// never in the critical path — so the warning here is a false positive.
 			chunkSizeWarningLimit: 600,
 		},
-		plugins: [tailwindcss()],
+		plugins: [tailwindcss(), pagesFunctionsDev()],
 	},
 });

--- a/scripts/pages-functions-dev.mjs
+++ b/scripts/pages-functions-dev.mjs
@@ -1,0 +1,45 @@
+import { spawn } from "node:child_process";
+
+export const PAGES_FUNCTIONS_PORT = 8788;
+
+// `astro dev` serves pages only, so every request to the API in functions/
+// returned a 404 in dev. Pages Functions need the workerd runtime, which only
+// `wrangler pages dev` provides. This plugin starts it beside the dev server
+// and stops it with the dev server; vite.server.proxy sends /api there, so the
+// browser still sees one origin.
+//
+// `public` is the static directory wrangler serves. Only /api is proxied, so
+// what it serves does not matter — this avoids a full build before every run.
+export function pagesFunctionsDev() {
+	return {
+		name: "pages-functions-dev",
+		apply: "serve",
+		configureServer(server) {
+			const child = spawn(
+				"wrangler",
+				["pages", "dev", "public", "--port", String(PAGES_FUNCTIONS_PORT), "--log-level", "warn"],
+				{ stdio: ["ignore", "inherit", "inherit"] },
+			);
+
+			child.on("error", (error) => {
+				server.config.logger.error(`[api] wrangler pages dev failed to start: ${error.message}`);
+			});
+
+			child.on("exit", (code) => {
+				if (code) server.config.logger.error(`[api] wrangler pages dev exited with code ${code}`);
+			});
+
+			let stopped = false;
+			function stop() {
+				if (stopped) return;
+				stopped = true;
+				child.kill("SIGTERM");
+			}
+
+			server.httpServer?.on("close", stop);
+			process.once("exit", stop);
+			process.once("SIGINT", stop);
+			process.once("SIGTERM", stop);
+		},
+	};
+}


### PR DESCRIPTION
Fixes the first half of #154: `/api/guestbook` returned 404 in `pnpm dev`.

## Cause

`pnpm dev` runs `astro dev`, which serves pages only. The API lives in `functions/` and runs as Cloudflare Pages Functions, and those need the workerd runtime that `wrangler pages dev` provides. So the guestbook island fetched a route that could not exist, logged a 404 on every mount, and fell back to its load error state. The only way to see a working guestbook was `pnpm guestbook:preview`, which rebuilds `dist` first and is not a dev loop.

## Change

`scripts/pages-functions-dev.mjs` is a Vite plugin with `apply: "serve"`. It starts `wrangler pages dev public --port 8788` when the dev server starts, and stops it on server close, `exit`, `SIGINT`, and `SIGTERM`. `vite.server.proxy` sends `/api` to that port, so the browser stays on one origin and cookies keep working.

`public` is the static directory wrangler serves. Only `/api` is proxied, so the choice does not matter, and it avoids a build before every run.

The plugin owns the child process instead of a task runner, because Astro 7 moves the dev server into the background and the foreground command exits. A runner like `concurrently` reads that exit as "astro stopped" and kills wrangler with it. Verified: `concurrently -k` killed the API within two seconds of start.

`pnpm dev` is unchanged. Port 8788 must be free.

## Verify

- `pnpm dev`, then `curl "http://localhost:4321/api/guestbook?offset=0&limit=3"` → 200 with rows from local D1
- `astro dev stop` → no orphan wrangler process
- `astro build` → no wrangler process starts, 26 pages built
- `pnpm check` → 0 errors

## Still open in #154

The `MaxListenersExceededWarning` does not reproduce from the command line. Details are in a comment on the issue, which stays open.
