### PR TITLE
feat(notes): morph the note title with view transitions

### DIFF
--- a/src/components/home/archive/archive-timeline-item.tsx
+++ b/src/components/home/archive/archive-timeline-item.tsx
@@ -1,4 +1,3 @@
-import { useMotionEnabled } from "@/hooks/use-motion";
 import { AccordionContent, AccordionItem, AccordionTrigger } from "../../ui/accordion";
 import { ArchiveDescriptions } from "./archive-descriptions";
 import { ArchivePhotos, type Photo } from "./archive-photos";
@@ -12,8 +11,6 @@ interface ArchiveTimelineItemProps {
 }
 
 export function ArchiveTimelineItem(props: ArchiveTimelineItemProps) {
-	const motionEnabled = useMotionEnabled();
-
 	return (
 		<AccordionItem
 			value={props.year}
@@ -41,14 +38,12 @@ export function ArchiveTimelineItem(props: ArchiveTimelineItemProps) {
 
 			<span
 				aria-hidden
-				data-safe-motion={motionEnabled}
-				className="absolute -left-2.25 top-5.25 hidden size-5 rounded-full bg-orange-500/75 group-first-of-type:block group-first-of-type:data-[safe-motion=true]:animate-ping"
+				className="absolute -left-2.25 top-5.25 hidden size-5 rounded-full bg-orange-500/75 group-first-of-type:block group-first-of-type:motion-on:animate-ping"
 			/>
 
 			<div
 				aria-hidden
-				data-safe-motion={motionEnabled}
-				className="absolute -left-1.5 top-[1.4688rem] size-3.5 rounded-xl border-2 border-taupe-300 dark:border-taupe-800 bg-background group-first-of-type:bg-orange-500 group-first-of-type:data-[safe-motion=true]:animate-in"
+				className="absolute -left-1.5 top-[1.4688rem] size-3.5 rounded-xl border-2 border-taupe-300 dark:border-taupe-800 bg-background group-first-of-type:bg-orange-500 group-first-of-type:motion-on:animate-in"
 			/>
 		</AccordionItem>
 	);

--- a/src/components/home/notes.astro
+++ b/src/components/home/notes.astro
@@ -35,7 +35,10 @@ const notesBase = localizePath("/notes", lang);
               {formatDate({ date: note.data.publishedAt, lang })}
             </time>
           </p>
-          <h3 class="pt-1 font-semibold tracking-tight text-balance transition-colors group-hover:text-orange-500 sm:text-lg">
+          <h3
+            data-note-title={slug}
+            class="pt-1 font-semibold tracking-tight text-balance transition-colors group-hover:text-orange-500 sm:text-lg"
+          >
             {note.data.title}
           </h3>
           <a

--- a/src/components/notes/note-article.astro
+++ b/src/components/notes/note-article.astro
@@ -7,6 +7,7 @@ import Seo from "@/components/shared/seo.astro";
 import { DotPattern } from "@/components/ui/dot-pattern";
 import type { Lang } from "@/i18n/config";
 import { getDictionary } from "@/i18n/dictionary";
+import { parseNoteId } from "@/i18n/utils";
 import { dateToISO, formatDate } from "@/lib/date";
 import type { Note } from "@/lib/notes";
 
@@ -22,6 +23,7 @@ const t = getDictionary(lang).notesPage;
 const { Content, headings } = await render(note);
 const author = await getEntry(note.data.author);
 
+const { slug } = parseNoteId(note.id);
 const { title, description, keywords, publishedAt } = note.data;
 const publishedTime = dateToISO(publishedAt);
 const authorName = author?.data.fullName ?? note.data.author.id;
@@ -39,6 +41,7 @@ const authorName = author?.data.fullName ?? note.data.author.id;
   <div class="relative">
     <header class="container-fluid pt-12 pb-6 lg:pt-24 lg:pb-12">
       <h1
+        data-note-title={slug}
         class="text-4xl leading-none font-bold tracking-tight text-pretty pb-8 sm:text-5xl lg:pb-16 lg:text-7xl"
       >
         {title}

--- a/src/components/notes/notes-cards.astro
+++ b/src/components/notes/notes-cards.astro
@@ -22,7 +22,10 @@ const notesBase = localizePath("/notes", lang);
             {formatDate({ date: note.data.publishedAt, lang })}
           </time>
         </p>
-        <h2 class="pt-1 text-lg font-semibold tracking-tight text-balance transition-colors group-hover:text-orange-500 sm:text-xl">
+        <h2
+          data-note-title={slug}
+          class="pt-1 text-lg font-semibold tracking-tight text-balance transition-colors group-hover:text-orange-500 sm:text-xl"
+        >
           {note.data.title}
         </h2>
         <p class="pt-1 text-sm text-muted-foreground">

--- a/src/components/now/happening-now.tsx
+++ b/src/components/now/happening-now.tsx
@@ -1,11 +1,9 @@
 import { ArrowUpRight } from "lucide-react";
-import { useMotionEnabled } from "@/hooks/use-motion";
 import type { Lang } from "@/i18n/config";
 import { getDictionary } from "@/i18n/dictionary";
 import { dateToISO, formatDate } from "@/lib/date";
 
 export function HappeningNow({ lang }: { lang: Lang }) {
-	const motionEnabled = useMotionEnabled();
 	const items = getDictionary(lang).now.items;
 	const sorted = Object.entries(items).sort(
 		([a], [b]) => new Date(b).getTime() - new Date(a).getTime(),
@@ -20,8 +18,7 @@ export function HappeningNow({ lang }: { lang: Lang }) {
 				>
 					<span
 						aria-hidden
-						data-safe-motion={motionEnabled}
-						className="absolute -left-2.25 top-0.5 hidden size-5 rounded-full bg-orange-500/75 group-first-of-type:block group-first-of-type:data-[safe-motion=true]:animate-ping"
+						className="absolute -left-2.25 top-0.5 hidden size-5 rounded-full bg-orange-500/75 group-first-of-type:block group-first-of-type:motion-on:animate-ping"
 					/>
 					<span
 						aria-hidden

--- a/src/components/shared/app-layout.astro
+++ b/src/components/shared/app-layout.astro
@@ -6,6 +6,7 @@ import { getLangFromPath } from "@/i18n/utils";
 import { ContactDialog } from "./contact/contact-dialog";
 import { Dock } from "./dock/dock";
 import Footer from "./footer.astro";
+import ViewTransitions from "./view-transitions.astro";
 
 interface Props {
 	bareWrapper?: boolean;
@@ -37,8 +38,21 @@ const lang = getLangFromPath(pathname);
               window.matchMedia("(prefers-color-scheme: dark)").matches);
           document.documentElement.classList.toggle("dark", dark);
         } catch {}
+
+        // Effective motion preference on the document, before paint: view
+        // transitions start before any island can hydrate. `useMotionSync`
+        // keeps it current after hydration.
+        try {
+          const motion = localStorage.getItem("motion-preference");
+          const enabled =
+            motion === "on" ||
+            (motion !== "off" &&
+              !window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+          document.documentElement.dataset.motion = enabled ? "on" : "off";
+        } catch {}
       })();
     </script>
+    <ViewTransitions />
     <slot name="metadata" />
   </head>
 

--- a/src/components/shared/dock/dock.tsx
+++ b/src/components/shared/dock/dock.tsx
@@ -2,7 +2,7 @@ import { DragDropProvider } from "@dnd-kit/react";
 import { useState } from "react";
 import { useDockPosition } from "@/hooks/use-dock-position";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { useMotionEnabled } from "@/hooks/use-motion";
+import { useMotionEnabled, useMotionSync } from "@/hooks/use-motion";
 import { useThemeSync } from "@/hooks/use-theme";
 import type { Lang } from "@/i18n/config";
 import { $dockPosition, isDockPosition } from "@/lib/stores/dock";
@@ -14,6 +14,7 @@ import { DockZone } from "./dock-zone";
 
 export function Dock({ pathname, lang }: { pathname: string; lang: Lang }) {
 	useThemeSync();
+	useMotionSync();
 
 	const position = useDockPosition();
 	const isMobile = useIsMobile();

--- a/src/components/shared/view-transitions.astro
+++ b/src/components/shared/view-transitions.astro
@@ -1,0 +1,55 @@
+---
+// Cross-document (native MPA) view transitions — no client router, so the site
+// stays static. The opt-in lives in `global.css`; this script pairs the note
+// title on both sides of a navigation so it morphs instead of cross-fading.
+//
+// The listeners must run before the first render opportunity of a document, so
+// this is an inline head script rather than a bundled module.
+---
+
+<script is:inline>
+  (() => {
+    const NOTE_PATH = /^(?:\/id)?\/notes\/([^/]+)\/?$/;
+    const NAME = "note-title";
+
+    function slugOf(url) {
+      if (!url) return null;
+      try {
+        return new URL(url, location.href).pathname.match(NOTE_PATH)?.[1] ?? null;
+      } catch {
+        return null;
+      }
+    }
+
+    function morph(transition, slug) {
+      if (document.documentElement.dataset.motion === "off") {
+        transition.skipTransition();
+        return;
+      }
+      if (!slug) return;
+
+      const title = document.querySelector(`[data-note-title="${CSS.escape(slug)}"]`);
+      if (!title) return;
+
+      title.style.viewTransitionName = NAME;
+      transition.finished.finally(() => {
+        title.style.viewTransitionName = "";
+      });
+    }
+
+    // The pair is keyed by the note slug: on a list page it is the card title of
+    // the note being opened, on an article page it is the heading itself. One of
+    // the two URLs carries the slug, so read the destination first.
+    addEventListener("pageswap", (event) => {
+      if (!event.viewTransition) return;
+      const to = event.activation?.entry.url;
+      morph(event.viewTransition, slugOf(to) ?? slugOf(location.href));
+    });
+
+    addEventListener("pagereveal", (event) => {
+      if (!event.viewTransition) return;
+      const from = window.navigation?.activation?.from?.url;
+      morph(event.viewTransition, slugOf(location.href) ?? slugOf(from));
+    });
+  })();
+</script>

--- a/src/hooks/use-motion.ts
+++ b/src/hooks/use-motion.ts
@@ -1,5 +1,6 @@
 import { useStore } from "@nanostores/react";
 import { useReducedMotion } from "motion/react";
+import { useEffect } from "react";
 import { $motionPreference } from "@/lib/stores/motion";
 
 /** Whether the user has made an explicit motion choice. */
@@ -18,4 +19,18 @@ export function useMotionEnabled() {
 	if (preference === "on") return true;
 	if (preference === "off") return false;
 	return !prefersReducedMotion;
+}
+
+/**
+ * Mirrors the effective preference onto `<html data-motion>`, which the view
+ * transition script reads — it runs before any island can hydrate, so it cannot
+ * use the store. First-paint application is handled by an inline script in the
+ * document head (see app-layout.astro). Mount once (in the dock).
+ */
+export function useMotionSync() {
+	const enabled = useMotionEnabled();
+
+	useEffect(() => {
+		document.documentElement.dataset.motion = enabled ? "on" : "off";
+	}, [enabled]);
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,6 +7,14 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Animations allowed — the stored preference combined with the OS setting, put
+   on <html> before paint (see app-layout.astro). Prefer this over Tailwind's
+   `motion-safe:`, which sees the OS setting only. Islands must not branch their
+   markup on the preference: it is unknown when the static HTML is built, so the
+   two renders disagree and hydration fails. A missing attribute (no JS) allows
+   animation, which is what the static HTML shows. */
+@custom-variant motion-on (&:is(html:not([data-motion="off"]) *));
+
 @theme {
 	--breakpoint-ssm: 25rem;
 }
@@ -142,6 +150,28 @@
 	html {
 		@apply font-sans;
 	}
+}
+
+/* Native cross-document view transitions. `view-transitions.astro` pairs the
+   note title between a list card and the article heading; everything else uses
+   the default root cross-fade. Motion-off skips the transition in that script. */
+@view-transition {
+	navigation: auto;
+}
+
+::view-transition-group(note-title) {
+	animation-duration: 320ms;
+	animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+/* The two headings differ in size, so the old snapshot is stretched while the
+   box morphs. Fade it out early and let the new one carry most of the move. */
+::view-transition-old(note-title) {
+	animation-duration: 120ms;
+}
+
+::view-transition-new(note-title) {
+	animation-duration: 220ms;
 }
 
 /* Wider reading container for long-form pages (notes). */


### PR DESCRIPTION
Adds view transitions between the note lists and a note. The title morphs: the card title in a list and the article heading are one element that moves and resizes.

## Change

Native cross-document view transitions, not `ClientRouter`. The site stays static output, and the islands keep their current load behaviour. `global.css` holds the opt-in.

`view-transitions.astro` pairs the two titles. It reads the note slug from the destination URL on a list page, or from the current URL on an article page, then puts `view-transition-name: note-title` on the matching `[data-note-title]` element just before the snapshot. The name is removed when the transition finishes, so only the two titles leave the root cross-fade. Both list pages carry the attribute, so the latest notes on the home page morph as well.

The listeners must exist before the first render opportunity of a document, so the file is an inline head script and not a bundled module.

The old heading fades out in 120 ms, because the two headings differ a lot in size (`text-lg` to `text-7xl`) and a stretched snapshot reads as blur.

## Motion preference

A transition starts before an island can hydrate, so the store cannot answer in time. The inline head script in `app-layout.astro` puts the effective preference on `<html data-motion>` before paint, next to the theme. The transition script calls `skipTransition()` when the value is off. The new `useMotionSync` hook keeps the attribute current after hydration, next to `useThemeSync` in the dock.

## Hydration fix

The now page and the home archive logged a React hydration error when the preference was off. The cause is older than this branch (#118): both islands rendered `data-safe-motion` from the preference. Both are `client:idle`, so the static HTML always said `true` while the client said `false` once the preference was off. With animations on the two values agreed, which is why only the off state failed.

The preference is unknown when the static HTML is built, so markup must not branch on it. The new `motion-on` variant reads the same document flag, and the two dots keep their animation in CSS. `HappeningNow` and `ArchiveTimelineItem` drop `useMotionEnabled`, so the two renders agree. This also removes a smaller flaw: the ping animated from first paint until hydration even when the preference was off.

The other `useMotionEnabled` callers pass a `transition` prop or a scroll behaviour. Those do not change the static markup and stay as they are.

## Verify

- `pnpm check` — 0 errors
- `astro build` — 26 pages built, `data-safe-motion` gone from `dist/index.html` and `dist/now/index.html`
- Generated selector — `.group-first-of-type\:motion-on\:animate-ping:is(:where(.group):first-of-type *):is(html:not([data-motion=off]) *)`

## Open

Browser checks are still needed on this branch: the morph in both directions, back navigation, and a clean console on the home page and the now page with animations off.

Support is Chromium only today. Other browsers get a plain navigation, which is the current behaviour.
